### PR TITLE
Find local codes using tax tags, schemes, and invoice type

### DIFF
--- a/body.go
+++ b/body.go
@@ -46,7 +46,7 @@ func newFatturaElettronicaBody(inv *bill.Invoice) (*FatturaElettronicaBody, erro
 	return &FatturaElettronicaBody{
 		DatiGenerali: DatiGenerali{
 			DatiGeneraliDocumento: DatiGeneraliDocumento{
-				TipoDocumento: TipoDocumentoDefault,
+				TipoDocumento: findCodeTipoDocumento(inv),
 				Divisa:        string(inv.Currency),
 				Data:          inv.IssueDate.String(),
 				Numero:        inv.Code,

--- a/codes.go
+++ b/codes.go
@@ -1,0 +1,89 @@
+package fatturapa
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/regimes/common"
+	"github.com/invopop/gobl/regimes/it"
+	"github.com/invopop/gobl/tax"
+)
+
+const (
+	regimeFiscaleCodeDefault = "RF01"
+	tipoDocumentoCodeDefault = "TD01"
+)
+
+var regime = tax.RegimeFor(l10n.IT, l10n.CodeEmpty)
+
+func findCodeRegimeFiscale(inv *bill.Invoice) string {
+	t := inv.Type.Key()
+
+	// based on the invoice type and the tax schemes used in the invoice,
+	// it iterates through the available schemes defined in gobl/it and fetches
+	// the corresponding regime fiscale code
+	for _, scheme := range regime.Schemes {
+		for _, invType := range scheme.InvoiceTypes {
+			for _, s := range inv.Tax.Schemes {
+				if t == invType && s == scheme.Key {
+					return scheme.Meta[it.KeyFatturaPARegimeFiscale]
+				}
+			}
+		}
+	}
+
+	return regimeFiscaleCodeDefault
+}
+
+func findCodeTipoDocumento(inv *bill.Invoice) string {
+	t := inv.Type.Key()
+
+	for _, scheme := range regime.Schemes {
+		for _, invType := range scheme.InvoiceTypes {
+			for _, s := range inv.Tax.Schemes {
+				if invType == t && scheme.Key == s {
+					return scheme.Meta[it.KeyFatturaPATipoDocumento]
+				}
+			}
+		}
+	}
+
+	return tipoDocumentoCodeDefault
+}
+
+func findCodeNatura(line *bill.Line) string {
+	var taxCategoryVAT *tax.Category
+
+	// get the italian VAT tax category
+	for _, cat := range regime.Categories {
+		if cat.Code == common.TaxCategoryVAT {
+			taxCategoryVAT = cat
+			break
+		}
+	}
+
+	var vatZeroTags []*tax.Tag
+
+	// get the list of available tags for the zero VAT rate
+	for _, rate := range taxCategoryVAT.Rates {
+		if rate.Key == common.TaxRateZero {
+			vatZeroTags = rate.Tags
+			break
+		}
+	}
+
+	if vatZeroTags == nil {
+		return ""
+	}
+
+	// check if the line has a tag for the zero VAT rate and return the
+	// corresponding code from the tag metadata
+	for _, tag := range vatZeroTags {
+		for _, tax := range line.Taxes {
+			if tax.Tag == tag.Key {
+				return tag.Meta[it.KeyFatturaPANatura]
+			}
+		}
+	}
+
+	return ""
+}

--- a/header.go
+++ b/header.go
@@ -31,7 +31,7 @@ func newFatturaElettronicaHeader(inv *bill.Invoice) (*FatturaElettronicaHeader, 
 		return nil, err
 	}
 
-	customer, err := newCessionarioCommittente(inv.Customer)
+	customer, err := newCessionarioCommittente(inv)
 	if err != nil {
 		return nil, err
 	}

--- a/items.go
+++ b/items.go
@@ -20,6 +20,7 @@ type DettaglioLinee struct {
 	PrezzoUnitario string
 	PrezzoTotale   string
 	AliquotaIVA    string
+	Natura         string `xml:",omitempty"`
 }
 
 type DatiRiepilogo struct {
@@ -56,6 +57,7 @@ func newDettaglioLinee(inv *bill.Invoice) []DettaglioLinee {
 			PrezzoUnitario: line.Item.Price.String(),
 			PrezzoTotale:   line.Sum.String(),
 			AliquotaIVA:    vatRate,
+			Natura:         findCodeNatura(line),
 		})
 	}
 

--- a/parties.go
+++ b/parties.go
@@ -3,6 +3,7 @@ package fatturapa
 import (
 	"errors"
 
+	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/org"
 )
 
@@ -47,7 +48,9 @@ type Anagrafica struct {
 	CodEORI string `xml:",omitempty"`
 }
 
-func newCedentePrestatore(s *org.Party) (*CedentePrestatore, error) {
+func newCedentePrestatore(inv *bill.Invoice) (*CedentePrestatore, error) {
+	s := inv.Supplier
+
 	address, err := newAddress(s)
 	if err != nil {
 		return nil, err
@@ -60,13 +63,15 @@ func newCedentePrestatore(s *org.Party) (*CedentePrestatore, error) {
 				IdCodice: s.TaxID.Code.String(),
 			},
 			Anagrafica:    newAnagrafica(s),
-			RegimeFiscale: RegimeFiscaleDefault,
+			RegimeFiscale: findCodeRegimeFiscale(inv),
 		},
 		Address: *address,
 	}, nil
 }
 
-func newCessionarioCommittente(c *org.Party) (*CessionarioCommittente, error) {
+func newCessionarioCommittente(inv *bill.Invoice) (*CessionarioCommittente, error) {
+	c := inv.Customer
+
 	address, err := newAddress(c)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is what it would look like form the Italy provider with the new `Tags` as well as `Scheme`+`InvoiceType` approach to mapping FatturaPA codes. I put everything in [codes.go](https://github.com/invopop/gobl.fatturapa/blob/79ba1e6b270576ccf7842d63076de0ebb3ef5020/codes.go) so it's easier to evaluate. 

What do you think? Feels like the logic is too complex and too dependent on gobl's inner workings to put inside of the provider... at the same time, I'm not sure moving this logic to gobl would make sense either, given it's pretty Italy-specific. Or maybe we can at least create a gobl functionality where you can fetch the scheme definitions based on on the invoice properties. Something like:

```go
regime := tax.RegimeFor(l10n.IT, l10n.CodeEmpty)

for _, schemeKey := range invoice.Schemes {
  schemeDef := regime.SchemeDefsFor(schemeKey, invoice.InvoiceType)
  // process
}  

```