### PR TITLE
Fetch causale pagamento code for retained taxes

### DIFF
--- a/body.go
+++ b/body.go
@@ -99,22 +99,22 @@ func extractInvoiceReasons(inv *bill.Invoice) []string {
 }
 
 func extractRetainedTaxes(inv *bill.Invoice) []DatiRitenuta {
-	var taxes []DatiRitenuta
+	var dr []DatiRitenuta
 
 	for _, tax := range inv.Totals.Taxes.Categories {
 		if tax.Retained {
-			code := regime.Category(tax.Code).Meta[it.KeyFatturaPANatura]
+			code := regime.Category(tax.Code).Meta[it.KeyFatturaPATipoRitenuta]
 
-			taxes = append(taxes, DatiRitenuta{
+			dr = append(dr, DatiRitenuta{
 				TipoRitenuta:     code,
 				ImportoRitenuta:  tax.Amount.String(),
 				AliquotaRitenuta: tax.Rates[0].Percent.String(),
-				CausalePagamento: "TODO",
+				CausalePagamento: findCodeCausalePagamento(inv, tax.Code),
 			})
 		}
 	}
 
-	return taxes
+	return dr
 }
 
 func extractPriceAdjustments(inv *bill.Invoice) []ScontoMaggiorazione {

--- a/codes.go
+++ b/codes.go
@@ -48,3 +48,27 @@ func findCodeNaturaZeroVat(line *bill.Line) string {
 
 	return ""
 }
+
+func findCodeCausalePagamento(inv *bill.Invoice, tc cbc.Code) string {
+	taxCategory := regime.Category(tc)
+
+	for _, line := range inv.Lines {
+		for _, tax := range line.Taxes {
+			if tax.Category == tc {
+				if len(tax.Tags) == 0 {
+					continue
+				}
+
+				for _, tag := range taxCategory.Tags {
+					for _, t := range tax.Tags {
+						if tag.Key == t {
+							return tag.Meta[it.KeyFatturaPACausalePagamento]
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return ""
+}

--- a/test/data/invoice-vat.json
+++ b/test/data/invoice-vat.json
@@ -114,7 +114,8 @@
 					{
 						"cat": "IRPEF",
 						"rate": "standard",
-						"percent": "20.0%"
+						"percent": "20.0%",
+						"tags": ["truffle-gathering"]
 					}
 				],
 				"total": "1620.00"


### PR DESCRIPTION
`DatiRitenuta` (Retained Taxes Data) contains 4 fields, `TipoRitenuta`, `ImportoRitenuta`, `AliquotaRitenuta`, and `CausalePagamento`. 

Building this element is complicated because `ImportoRitenuta` (amount) is found in `Invoice.Totals.Taxes.Categories` while `CausalePagamento` depends on tax tags that are only added at the line level. (see `codes.go`) 

Current format also makes it difficult for the document to have an arbitrary combination of `TipoRitenuta`s and `CausalePagamento`s, which the Italian system allows. To select retained taxes, one has to look at the `Retained` field in `CategoryTotals`, but since all instances of the same tax category are combined at the totals level, we would have to do further calculations based on rates defined at the line level to compute `ImportoRitenuta`. 
