### PR TITLE
Always include codice destinatario if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ if err != nil {
 }
 ```
 
-If you want to include the fiscal data of the entity integrating with the SDI (Italy's e-invoice system) and `ProgressivoInvio` (transmission number) in the XML, you can use the `WithTransmissionData` option. This option must be used if you are integrating diredctly with the SDI, but if you are working with a third party service to send the XML, it would be on their side to include this data.
+If you want to include the fiscal data of the entity integrating with the SDI (Italy's e-invoice system) and `ProgressivoInvio` (transmission number) in the XML, you can use the `WithTransmitterData` option. This option must be used if you are integrating diredctly with the SDI, but if you are working with a third party service to send the XML, it would be on their side to include this data.
 
 ```golang
 transmitter := fatturapa.Transmitter{
@@ -70,7 +70,7 @@ transmitter := fatturapa.Transmitter{
 }
 
 converter := fatturapa.NewConverter(
-    fatturapa.WithTransmissionData(transmitter),
+    fatturapa.WithTransmitterData(transmitter),
     // other options
 )
 ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ if err != nil {
 }
 ```
 
-If you want to include the `DatiTrasmissione` (transmission data) in the XML, you can use the `WithTransmissionData` option. This will include the fiscal data of the entity integrating with the SDI (Italy's e-invoice system) and `ProgressivoInvio` (transmission number) in the XML. This field must be present when the invoice reaches the Italian system, but if you are working with a third party service to send the XML, it would be on their side to include this data.
+If you want to include the fiscal data of the entity integrating with the SDI (Italy's e-invoice system) and `ProgressivoInvio` (transmission number) in the XML, you can use the `WithTransmissionData` option. This option must be used if you are integrating diredctly with the SDI, but if you are working with a third party service to send the XML, it would be on their side to include this data.
 
 ```golang
 transmitter := fatturapa.Transmitter{

--- a/cmd/gobl.fatturapa/convert.go
+++ b/cmd/gobl.fatturapa/convert.go
@@ -91,7 +91,7 @@ func loadConverterFromConfig(c *convertOpts) (*fatturapa.Converter, error) {
 			TaxID:       taxID,
 		}
 
-		opts = append(opts, fatturapa.WithTransmissionData(&transmitter))
+		opts = append(opts, fatturapa.WithTransmitterData(&transmitter))
 	}
 
 	if c.cert != "" {

--- a/converter.go
+++ b/converter.go
@@ -28,7 +28,7 @@ type Config struct {
 
 type Option func(*Converter)
 
-func WithTransmissionData(transmitter *Transmitter) Option {
+func WithTransmitterData(transmitter *Transmitter) Option {
 	return func(c *Converter) {
 		c.Config.Transmitter = transmitter
 	}

--- a/test/converter.go
+++ b/test/converter.go
@@ -25,7 +25,7 @@ func TestConverter() *fatturapa.Converter {
 	}
 
 	converter := fatturapa.NewConverter(
-		fatturapa.WithTransmissionData(transmitter),
+		fatturapa.WithTransmitterData(transmitter),
 		fatturapa.WithCertificate(cert),
 	)
 

--- a/transmission.go
+++ b/transmission.go
@@ -25,15 +25,17 @@ const InboxKeyCodiceDestinatario = "codice-destinatario"
 
 // Data related to the transmitting subject
 type DatiTrasmissione struct {
-	IdTrasmittente      TaxID
-	ProgressivoInvio    string
-	FormatoTrasmissione string
+	IdTrasmittente      TaxID  `xml:",omitempty"`
+	ProgressivoInvio    string `xml:",omitempty"`
+	FormatoTrasmissione string `xml:",omitempty"`
 	CodiceDestinatario  string
 }
 
 func (c *Converter) newDatiTrasmissione(inv *bill.Invoice, env *gobl.Envelope) *DatiTrasmissione {
 	if c.Config.Transmitter == nil {
-		return nil
+		return &DatiTrasmissione{
+			CodiceDestinatario: codiceDestinatario(inv.Customer),
+		}
 	}
 
 	return &DatiTrasmissione{

--- a/transmission_test.go
+++ b/transmission_test.go
@@ -23,7 +23,7 @@ func TestTransmissionData(t *testing.T) {
 		assert.Equal(t, "ABCDEF1", dt.CodiceDestinatario)
 	})
 
-	t.Run("should skip transmission info if transmitter is not present", func(t *testing.T) {
+	t.Run("should skip transmitter info and only include codice destinatario if transmitter is not present", func(t *testing.T) {
 		converter := test.TestConverter()
 
 		converter.Config.Transmitter = nil
@@ -31,6 +31,12 @@ func TestTransmissionData(t *testing.T) {
 		doc, err := test.LoadGOBL("invoice-simple.json", converter)
 		require.NoError(t, err)
 
-		assert.Nil(t, doc.FatturaElettronicaHeader.DatiTrasmissione)
+		dt := doc.FatturaElettronicaHeader.DatiTrasmissione
+
+		assert.Equal(t, "ABCDEF1", dt.CodiceDestinatario)
+		assert.Equal(t, "", dt.IdTrasmittente.IdPaese)
+		assert.Equal(t, "", dt.IdTrasmittente.IdCodice)
+		assert.Equal(t, "", dt.ProgressivoInvio)
+		assert.Equal(t, "", dt.FormatoTrasmissione)
 	})
 }


### PR DESCRIPTION
- We were excluding the entire `DatiTrasmissione`  block unless the `WithTransmissionData` option was present. 
- `CodiceDestinatario` is part of `DatiTrasmissione`, and it should be included whether the option is set or not—only fields that should be excluded are `IdTrasmittente`, `ProgressivoInvio`, and `FormatoTrasmissione`
- Rename `WithTransmissionData` option to `WithTransmitterData` to make this clearer.