### PR TITLE
Basic server side communication

### DIFF
--- a/cmd/gobl.fatturapa/root.go
+++ b/cmd/gobl.fatturapa/root.go
@@ -23,6 +23,7 @@ func (o *rootOpts) cmd() *cobra.Command {
 	cmd.AddCommand(versionCmd())
 	cmd.AddCommand(convert(o).cmd())
 	cmd.AddCommand(transmit(o).cmd())
+	cmd.AddCommand(server(o).cmd())
 
 	return cmd
 }

--- a/cmd/gobl.fatturapa/server.go
+++ b/cmd/gobl.fatturapa/server.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+
+	sdi "github.com/invopop/gobl.fatturapa/sdi"
+	"github.com/spf13/cobra"
+)
+
+type serverOpts struct {
+	*rootOpts
+}
+
+func server(o *rootOpts) *serverOpts {
+	return &serverOpts{rootOpts: o}
+}
+
+func (c *serverOpts) cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "server [host] [port]",
+		Short: "Server for communication with SdI in selected environment",
+		RunE:  c.runE,
+	}
+
+	f := cmd.Flags()
+	f.BoolP("verbose", "v", false, "Logs all requests into the console")
+	f.String("ca-cert", "", "Path to a file containing the CA certificate")
+	f.String("cert", "", "Path to a file containing the certificate")
+	f.String("key", "", "Path to a file containing the certificate key")
+	f.String("client-auth", "RequireAndVerifyClientCert", "Client authentication type (NoClientCert, RequestClientCert, RequireAnyClientCert, VerifyClientCertIfGiven, RequireAndVerifyClientCert)")
+	_ = cmd.MarkFlagRequired("ca-cert")
+	_ = cmd.MarkFlagRequired("cert")
+	_ = cmd.MarkFlagRequired("key")
+
+	return cmd
+}
+
+func (c *serverOpts) runE(cmd *cobra.Command, args []string) error {
+	host := inputHost(args)
+	port := inputPort(args)
+
+	verbose, err := cmd.Flags().GetBool("verbose")
+	if err != nil {
+		return err
+	}
+
+	caCertPEM, err := loadDataFromFlag(cmd, "ca-cert")
+	if err != nil {
+		return err
+	}
+
+	certPEM, err := loadDataFromFlag(cmd, "cert")
+	if err != nil {
+		return err
+	}
+
+	keyPEM, err := loadDataFromFlag(cmd, "key")
+	if err != nil {
+		return err
+	}
+
+	tlsCert, err := loadTLSCert(certPEM, keyPEM)
+	if err != nil {
+		return err
+	}
+
+	caCertPool, err := loadCertPoolFromPEM(caCertPEM)
+	if err != nil {
+		return err
+	}
+
+	clientAuth, err := getClientAuthTypeFromFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	if verbose {
+		log.Printf("Server start: %s:%s\n", host, port)
+		log.Printf("Client auth: %s\n", clientAuth)
+	}
+
+	config := &sdi.ServerConfig{
+		Host:       host,
+		Port:       port,
+		Verbose:    verbose,
+		CACert:     caCertPool,
+		CertAuth:   tlsCert,
+		ClientAuth: clientAuth,
+	}
+
+	err = sdi.RunServer(config, sdi.MessageHandler)
+	if err != nil {
+		return fmt.Errorf("server error: %w", err)
+	}
+
+	return nil
+}
+
+func inputHost(args []string) string {
+	if len(args) > 0 && args[0] != "-" {
+		return args[0]
+	}
+	return ""
+}
+
+func inputPort(args []string) string {
+	if len(args) > 1 && args[1] != "-" {
+		return args[1]
+	}
+	return ""
+}
+
+func loadTLSCert(publicCertPEM, privateKeyPEM []byte) (tls.Certificate, error) {
+	serverTLSCert, err := tls.X509KeyPair(publicCertPEM, privateKeyPEM)
+	if err != nil {
+		return serverTLSCert, err
+	}
+
+	return serverTLSCert, nil
+}
+
+func loadCertPoolFromPEM(caCertPEM []byte) (*x509.CertPool, error) {
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		caCertPool = x509.NewCertPool()
+	}
+
+	if !caCertPool.AppendCertsFromPEM(caCertPEM) {
+		return nil, fmt.Errorf("no certificates appended")
+	}
+
+	return caCertPool, nil
+}
+
+var clientAuthTypes = map[string]tls.ClientAuthType{
+	"NoClientCert":               tls.NoClientCert,
+	"RequestClientCert":          tls.RequestClientCert,
+	"RequireAnyClientCert":       tls.RequireAnyClientCert,
+	"VerifyClientCertIfGiven":    tls.VerifyClientCertIfGiven,
+	"RequireAndVerifyClientCert": tls.RequireAndVerifyClientCert,
+}
+
+func getClientAuthTypeFromFlag(cmd *cobra.Command) (tls.ClientAuthType, error) {
+	flagName := "client-auth"
+	clientAuthTypeName, err := cmd.Flags().GetString(flagName)
+	if err != nil {
+		return tls.NoClientCert, fmt.Errorf("failed to get value of flag %s: %w", flagName, err)
+	}
+
+	clientAuthType, ok := clientAuthTypes[clientAuthTypeName]
+	if !ok {
+		return tls.NoClientCert, fmt.Errorf("invalid client authentication type: %s", clientAuthTypeName)
+	}
+
+	return clientAuthType, nil
+}

--- a/cmd/gobl.fatturapa/server.go
+++ b/cmd/gobl.fatturapa/server.go
@@ -91,7 +91,9 @@ func (c *serverOpts) runE(cmd *cobra.Command, args []string) error {
 		ClientAuth: clientAuth,
 	}
 
-	err = sdi.RunServer(config, sdi.MessageHandler)
+	messageHandler := sdi.MessageHandler(handleRequest)
+
+	err = sdi.RunServer(config, messageHandler)
 	if err != nil {
 		return fmt.Errorf("server error: %w", err)
 	}
@@ -120,6 +122,18 @@ func loadTLSCert(publicCertPEM, privateKeyPEM []byte) (tls.Certificate, error) {
 	}
 
 	return serverTLSCert, nil
+}
+
+func handleRequest(env *sdi.Envelope) {
+	if env.Body.FileSubmissionMetadata != nil {
+		log.Printf("parsing MetadatiInvioFile:\n")
+	}
+	if env.Body.NonDeliveryNotificationMessage != nil {
+		log.Printf("parsing NotificaMancataConsegna:\n")
+	}
+	if env.Body.InvoiceTransmissionCertificate != nil {
+		log.Printf("parsing AttestazioneTrasmissioneFattura:\n")
+	}
 }
 
 func loadCertPoolFromPEM(caCertPEM []byte) (*x509.CertPool, error) {

--- a/cmd/gobl.fatturapa/transmit.go
+++ b/cmd/gobl.fatturapa/transmit.go
@@ -31,7 +31,7 @@ func (c *transmitOpts) cmd() *cobra.Command {
 	f.String("ca-cert", "", "Path to a file containing the CA certificate")
 	f.String("cert", "", "Path to a file containing the SDI PEM certificate")
 	f.String("key", "", "Path to a file containing the sender PEM RSA private key")
-	f.String("env", "test", "Environment for running command")
+	f.StringP("env", "e", "test", "Environment for running command")
 	_ = cmd.MarkFlagRequired("ca-cert")
 	_ = cmd.MarkFlagRequired("cert")
 	_ = cmd.MarkFlagRequired("key")

--- a/docs/sdi/ERRORS.md
+++ b/docs/sdi/ERRORS.md
@@ -1,0 +1,63 @@
+# Error List
+
+## Empty SOAP request
+
+Response to an empty string sent instead of a SOAP request with invoice.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
+  <soapenv:Body>
+    <soapenv:Fault>
+      <soapenv:Code>
+        <soapenv:Value>soapenv:Receiver</soapenv:Value>
+      </soapenv:Code>
+      <soapenv:Reason>
+        <soapenv:Text xml:lang="en-US">javax.xml.stream.XMLStreamException: The root element is required in a well-formed document.</soapenv:Text>
+      </soapenv:Reason>
+      <soapenv:Detail></soapenv:Detail>
+    </soapenv:Fault>
+  </soapenv:Body>
+</soapenv:Envelope>
+```
+
+Status Code: 500 Internal Server Error
+
+## SOAP request without Body
+
+Response to sending SOAP request without `<soapenv:Body>` part.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+  <soapenv:Body>
+    <soapenv:Fault xmlns:axis2ns1="http://schemas.xmlsoap.org/soap/envelope/">
+      <faultcode>axis2ns1:Server</faultcode>
+      <faultstring>Internal Error</faultstring>
+      <detail></detail>
+    </soapenv:Fault>
+  </soapenv:Body>
+</soapenv:Envelope>
+```
+
+Status Code: 500 Internal Server Error
+
+## Empty invoice
+
+Response to sending an empty invoice file.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+  <soapenv:Body>
+    <ns2:rispostaSdIRiceviFile
+      xmlns:ns2="http://www.fatturapa.gov.it/sdi/ws/trasmissione/v1.0/types">
+      <IdentificativoSdI>0</IdentificativoSdI>
+      <DataOraRicezione>2024-06-11T12:00:00.000+02:00</DataOraRicezione>
+      <Errore>EI01</Errore>
+    </ns2:rispostaSdIRiceviFile>
+  </soapenv:Body>
+</soapenv:Envelope>
+```
+
+Status Code: 200 OK

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/terminalstatic/go-xsd-validate v0.1.5
 	gitlab.com/flimzy/testy v0.12.4
+	golang.org/x/net v0.25.0
 )
 
 require (
@@ -35,8 +36,8 @@ require (
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
-	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/text v0.15.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	software.sslmate.com/src/go-pkcs12 v0.2.0 // indirect
 )

--- a/sdi/README.md
+++ b/sdi/README.md
@@ -85,3 +85,53 @@ $ openssl pkcs12 -export -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -nomac -ou
 Enter Export Password:
 Verifying - Enter Export Password:
 ```
+
+## Receive an invoice
+
+### Development
+
+To communicate with the server the client need:
+
+- file with CA certificates in PEM format
+- PEM certificate (see the Certificator_Server folder)
+- PEM RSA private key (generated during initial registration process)
+
+The server must use HTTPS.
+Since certificates are associated with a domain,
+we need to convince our local DNS that this is the right domain.
+
+In this example the domain used will be `sdi-it.invopop.com`.
+
+Set this domain in the `/etc/hosts` file to point to `0.0.0.0`.
+
+```console
+$ cat /etc/hosts | grep sdi
+0.0.0.0		sdi-it.invopop.com
+```
+
+Run the server in one console:
+
+```console
+$ go run ./cmd/gobl.fatturapa server --ca-cert ./ca-all.pem --cert ./SDI-IT.INVOPOP.COM.pem --key ./key_server.key --verbose sdi-it.invopop.com 8080
+Server start: sdi-it.invopop.com:8080
+Client auth: RequireAndVerifyClientCert
+Incoming request:
+GET / HTTP/2.0
+Host: sdi-it.invopop.com:8080
+Accept: */*
+User-Agent: curl/7.88.1
+
+Outgoing response:
+HTTP/2.0 200 OK
+Content-Length: 2
+Content-Type: text/plain
+
+OK
+```
+
+In another console, send requests:
+
+```console
+$ curl --cacert ./ca-all.pem --cert ./SDI-IT.INVOPOP.COM.pem --key ./key_server.key https://sdi-it.invopop.com:8080
+OK
+```

--- a/sdi/README.md
+++ b/sdi/README.md
@@ -150,3 +150,111 @@ Any attempts from SdI will only be visible in the simulation section
 of the "Manage the channel" interface.
 
 ---
+
+## TODO
+
+- [X] completed tasks
+- [ ] uncompleted tasks
+
+Below is a checklist.
+It is intended to help us determine the current status of the project.
+
+### Sending invoices
+
+The functionality related to sending invoices
+and simple invoices works correctly (tested in test env for SdI).
+The status of sent invoices is visible
+in the "Interoperability Test" section of "Manage the channel".
+
+- [X] Sending invoices to SdI
+  - [X] Building the client along with configuration
+  - [X] Preparation of SOAP request for SdI
+  - [X] Creation of "transmit" command for CLI
+  - [X] Adding SSL support to the HTTP client for sending invoices
+- [X] Receiving responses after sending invoices:
+  - [X] Parses a multipart HTTP response (XOP+XML)
+  - [X] Deserialization of response into appropriate structure
+- [X] Handling errors:
+  - [X] Empty invoice (File vuoto)
+  - [X] Service unavailable (Servizio non disponibile)
+  - [X] Unauthorized user (Utente non abilitato)
+  - [X] File type not correct (Tipo file non corretto)
+- [X] Preparation of structures for Message Types (based on MessaggiTypes_v1.1.xsd)
+
+### Receiving invoices
+
+The functionality of receiving invoices and notifications is not working
+because we couldn't configure SSL communication correctly.
+When we send an invoice to the recipient specified in the "Manage the channel"
+simulation section, the our server should receive it.
+SdI makes three attempts to deliver the invoice or notification.
+However, for this to happen, SdI tries to authenticate the server
+it sends data to at the SSL level.
+
+If any requests were to arrive, we would see them in the server logs.
+Currently, the status of sent requests is visible only in "Manage the channel",
+with the following message:
+
+> javax.net.ssl.SSLHandshakeException [1]: General SSLEngine problem
+
+Despite SSL issues, some tasks were successfully completed (based on tests).
+
+- [ ] Receiving invoices from SdI
+  - [X] Simple HTTP server listening on the selected port
+  - [X] Adding SSL support to the HTTPS server
+  - [X] Building a message handler
+  - [ ] Handling transmission service endpoint (out)
+  - [ ] Handling reception service endpoint (in)
+  - [X] Creation of "server" command for CLI
+  - [ ] Parsing request from SdI with the invoice
+  - [ ] Assign parsed invoice to GOBL format
+- [ ] Receiving notifications from SdI
+  - [X] Handling different SdI requests
+  - [ ] Receiving actual requests from SDI for testing purposes
+  - [X] Mocking real communication with SDI for testing purposes
+- [X] Parsing SDI messages:
+  - [X] Rejection Receipt (RicevutaScarto)
+  - [ ] Invoice Transmission Confirmation (AttestazioneTrasmissioneFattura)
+  - [X] File Submission Metadata (MetadatiInvioFile)
+  - [ ] Delivery Failure Notification (NotificaMancataConsegna)
+- [ ] Server configuration
+  - [X] Analysis of requirements needed for server configuration
+  - [ ] Setting up the server for "Interoperability Tests"
+  - [ ] Setting up the server for production
+- [X] Preparing the structure based on XSD files:
+  - [X] Invoice Data Message (DatiFatturaMessaggi_v2.0.xsd)
+  - [X] Receipt Types (RicezioneTypes_v1.0.xsd)
+  - [X] Submission File Types
+  - [X] Transmission File Types (TrasmissioneFileTypes_v2.0.xsd)
+  - [X] Transmission Types (TransmissioneTypes_v1.1.xsd)
+
+The above tasks likely do not cover all the preparations required.
+However, without the ability to receive requests from SdI,
+the development process is hindered.
+
+### Interoperability Test
+
+To pass the "Interoperability Test", a correctly configured environment
+with an active server is required. SdI does not allow the use of two different
+certificates, so the staging environment should be on the same domain
+as the production environment. The difference may lie in a different path,
+which can be set in the "Change Endpoint" section of "Manage the Channel".
+
+Necessary tests to pass:
+
+- [ ] Invoice Reception (Ricezione Fattura)
+- [ ] Delivery Receipt (Ricevuta consegna)
+- [ ] Non-Delivery Notification (B2G)/Undeliverable Notification (B2B, B2C) (Notifica mancata consegna (B2G)/Notifica impossibilità di recapito (B2B, B2C))
+- [ ] Rejection Notification (B2G)/Rejection Receipt (B2B, B2C) (Notifica scarto (B2G)/Ricevuta di scarto (B2B, B2C))
+
+Further tests for FatturaPA:
+
+- [ ] Outcome Notification from PA (Notifica di esito da PA)
+- [ ] Rejection Notification of Outcome to PA (Notifica di Scarto esito a PA)
+- [ ] Deadline Notification to PA (Notifica Decorrenza Termini a PA)
+- [ ] Outcome Notification to Economic Operator (Notifica esito a Operatore Economico)
+- [ ] Deadline Notification to Economic Operator (Notifica Decorrenza Termini a Operatore Economico)
+- [ ] Transmission Confirmation (Attestazione avvenuta trasmissione)
+
+After successfully passing the interoperability tests, SdI will be unlocked
+to communicate with the production environment of the SDICoop Web Service.

--- a/sdi/README.md
+++ b/sdi/README.md
@@ -2,11 +2,11 @@
 
 ## SDICoop Web Service
 
-### Test
+### Test endpoint
 
 - [Test URI](https://testservizi.fatturapa.it/)
 
-### Production
+### Production endpoint
 
 - [Production URI](https://fatturapa.it/)
 
@@ -29,6 +29,7 @@ After logging in, we have access to the following options:
 ## Send an invoice
 
 To send an invoice you need:
+
 - invoice file in XML format
 - file with CA certificates in PEM format
 - PEM certificate (see the Certificato_Client folder)
@@ -74,11 +75,9 @@ Content-ID: <0.182152212d14b303688146ac0db42b507ac086a479534824@apache.org>
 ==============================================================================
 ```
 
-## Links
-
-- [Manage the channel](https://sdi.fatturapa.gov.it/SdI2FatturaPAWebSpa/GestireCanaleAction.do)
-
 ## Receive an invoice
+
+To receive invoices and notifications, you need to set up a server communicating with SdI.
 
 ### Development
 
@@ -127,3 +126,27 @@ In another console, send requests:
 $ curl --cacert ./ca-all.pem --cert ./SDI-IT.INVOPOP.COM.pem --key ./key_server.key https://sdi-it.invopop.com:8080
 OK
 ```
+
+### Production
+
+#### Pre-requirements
+
+Read [instructions for creating the CSR using OpenSSL commands](https://www.fatturapa.gov.it/it/norme-e-regole/DocumentazioneSDI/) / SDICoop Service / Example of CSR generation using OpenSSL commands (for expert users).
+
+To ensure proper functionality, the Common Name (CN) of the SSL certificate
+should match the DNS name of the endpoint it is used with.
+Mismatch lead to authentication issues.
+
+SdI uses two-way SSL authentication, where both the client (SdI)
+and the server (your endpoint) exchange certificates for authentication.
+The server must have a certificate issued by
+[Agenzia delle Entrate](https://www.agenziaentrate.gov.it/portale/)
+configured to the IP address, not the domain,
+due to SdI not supporting SNI (Server Name Indication).
+
+Failure to meet the above requirements will result in communication
+being blocked at the TLS level.
+Any attempts from SdI will only be visible in the simulation section
+of the "Manage the channel" interface.
+
+---

--- a/sdi/README.md
+++ b/sdi/README.md
@@ -78,14 +78,6 @@ Content-ID: <0.182152212d14b303688146ac0db42b507ac086a479534824@apache.org>
 
 - [Manage the channel](https://sdi.fatturapa.gov.it/SdI2FatturaPAWebSpa/GestireCanaleAction.do)
 
-## Pfx server certificate
-
-```
-$ openssl pkcs12 -export -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -nomac -out SDI-PIVA-SERVER.pfx -inkey key_server.key -in SDI-IT.INVOPOP.COM.pem -certfile ca-all.pem
-Enter Export Password:
-Verifying - Enter Export Password:
-```
-
 ## Receive an invoice
 
 ### Development

--- a/sdi/helper_test.go
+++ b/sdi/helper_test.go
@@ -1,0 +1,75 @@
+package sdi_test
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"testing"
+
+	sdi "github.com/invopop/gobl.fatturapa/sdi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func handlerFunc(env *sdi.Envelope) {
+	if env.Body.FileSubmissionMetadata != nil {
+		log.Printf("parsing MetadatiInvioFile:\n")
+	}
+	if env.Body.NonDeliveryNotificationMessage != nil {
+		log.Printf("parsing NotificaMancataConsegna:\n")
+	}
+	if env.Body.InvoiceTransmissionCertificate != nil {
+		log.Printf("parsing AttestazioneTrasmissioneFattura:\n")
+	}
+}
+
+func TestParseMessage(t *testing.T) {
+	t.Run("parse MetadatiInvioFile", func(t *testing.T) {
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		defer func() {
+			log.SetOutput(os.Stderr)
+		}()
+
+		reader, err := os.Open("./test/examples/ESB85905495_00010_MT_001.xml")
+		require.NoError(t, err)
+
+		err = sdi.ParseMessage(io.NopCloser(reader), handlerFunc)
+		require.NoError(t, err)
+
+		assert.Contains(t, buf.String(), "parsing MetadatiInvioFile")
+	})
+
+	t.Run("parse NotificaMancataConsegna", func(t *testing.T) {
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		defer func() {
+			log.SetOutput(os.Stderr)
+		}()
+
+		reader, err := os.Open("./test/examples/ESB85905495_00010_MT_004.xml")
+		require.NoError(t, err)
+
+		err = sdi.ParseMessage(io.NopCloser(reader), handlerFunc)
+		require.NoError(t, err)
+
+		assert.Contains(t, buf.String(), "parsing NotificaMancataConsegna")
+	})
+
+	t.Run("parse AttestazioneTrasmissioneFattura", func(t *testing.T) {
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		defer func() {
+			log.SetOutput(os.Stderr)
+		}()
+
+		reader, err := os.Open("./test/examples/ESB85905495_00010_MT_005.xml")
+		require.NoError(t, err)
+
+		err = sdi.ParseMessage(io.NopCloser(reader), handlerFunc)
+		require.NoError(t, err)
+
+		assert.Contains(t, buf.String(), "parsing AttestazioneTrasmissioneFattura")
+	})
+}

--- a/sdi/invoice.go
+++ b/sdi/invoice.go
@@ -45,7 +45,7 @@ func SendInvoice(ctx context.Context, invOpts InvoiceOpts, c *Client, cfg Config
 		return nil, err
 	}
 
-	return response, nil
+	return response, getErrorMessageFromResponse(*response)
 }
 
 // SoapRequestToSendInvoice prepares the request content for SOAP to send an invoice
@@ -62,4 +62,39 @@ func SoapRequestToSendInvoice(fileName string, fileBody []byte) string {
 		`</typ:fileSdIAccoglienza>` +
 		`</soapenv:Body>` +
 		`</soapenv:Envelope>`
+}
+
+const (
+	// EmptyFileError represents error for empty invoice file
+	EmptyFileError = "EI01" // FILE VUOTO
+
+	// ServiceUnavailableError represents error when service is unavailable
+	ServiceUnavailableError = "EI02" // SERVIZIO NON DISPONIBILE
+
+	// UnauthorizedUserError represents error for unauthorized user
+	UnauthorizedUserError = "EI03" // UTENTE NON ABILITATO
+
+	// IncorrectFileTypeError represents error for incorrect file type
+	IncorrectFileTypeError = "EI04" // TIPO FILE NON CORRETTO
+)
+
+func getErrorMessageFromResponse(response SendInvoiceResponse) error {
+	respErr := response.Body.Response.Error
+	if respErr == nil {
+		return nil
+	}
+
+	errors := map[string]string{
+		EmptyFileError:          "attached file is empty",
+		ServiceUnavailableError: "service momentarily unavailable",
+		UnauthorizedUserError:   "unauthorized user",
+		IncorrectFileTypeError:  "file type not correct",
+	}
+
+	errCode := errors[respErr.ErrorCode]
+	if errCode == "" {
+		return fmt.Errorf("unknown error code: %v", respErr)
+	}
+
+	return fmt.Errorf(errCode)
 }

--- a/sdi/invoice_data_messages.go
+++ b/sdi/invoice_data_messages.go
@@ -31,6 +31,7 @@ type ErrorListType struct {
 
 // ErrorType represents the Errore element.
 type ErrorType struct {
-	Code        string `xml:"Codice"`
-	Description string `xml:"Descrizione"`
+	Code        string  `xml:"Codice"`
+	Description string  `xml:"Descrizione"`
+	Suggestion  *string `xml:"Suggerimento,omitempty"`
 }

--- a/sdi/message.go
+++ b/sdi/message.go
@@ -1,0 +1,69 @@
+package sdi
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+)
+
+// MessageHandler processes SOAP requests from SdI (Sistema di Interscambio)
+func MessageHandler(w http.ResponseWriter, req *http.Request) {
+	requestDump, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		log.Printf("Failed to dump incoming request: %s\n", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	log.Printf("Incoming request:\n%s", requestDump)
+
+	responseBody := []byte(soapEmptyResponse())
+	response := &http.Response{
+		Status:        "200 OK",
+		StatusCode:    http.StatusOK,
+		Proto:         "HTTP/2.0",
+		ProtoMajor:    2,
+		ProtoMinor:    0,
+		Body:          io.NopCloser(bytes.NewReader(responseBody)),
+		ContentLength: int64(len(responseBody)),
+		Header:        make(http.Header),
+	}
+	// contentType := http.DetectContentType(responseBody)
+	response.Header.Set("Content-Type", "application/soap+xml")
+
+	responseDump, err := httputil.DumpResponse(response, true)
+	if err != nil {
+		log.Printf("Failed to dump outgoing response: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	log.Printf("Outgoing response:\n%s", responseDump)
+
+	err = responseToWriter(w, response)
+	if err != nil {
+		log.Printf("Failed to send response: %v", err)
+		return
+	}
+}
+
+func responseToWriter(w http.ResponseWriter, response *http.Response) error {
+	w.WriteHeader(response.StatusCode)
+
+	for k, v := range response.Header {
+		for _, vv := range v {
+			w.Header().Add(k, vv)
+		}
+	}
+
+	_, ok := io.Copy(w, response.Body)
+	return ok
+}
+
+func soapEmptyResponse() string {
+	return `<?xml version='1.0' encoding='UTF-8'?>` +
+		`<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/' xmlns:typ='http://www.fatturapa.gov.it/sdi/ws/trasmissione/v1.0/types'>` +
+		`<soapenv:Header/>` +
+		`<soapenv:Body/>` +
+		`</soapenv:Envelope>`
+}

--- a/sdi/message.go
+++ b/sdi/message.go
@@ -9,41 +9,50 @@ import (
 )
 
 // MessageHandler processes SOAP requests from SdI (Sistema di Interscambio)
-func MessageHandler(w http.ResponseWriter, req *http.Request) {
-	requestDump, err := httputil.DumpRequest(req, true)
-	if err != nil {
-		log.Printf("Failed to dump incoming request: %s\n", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-	log.Printf("Incoming request:\n%s", requestDump)
+func MessageHandler(handler HandleSOAPRequest) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		requestDump, err := httputil.DumpRequest(req, true)
+		if err != nil {
+			log.Printf("Failed to dump incoming request: %s\n", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		log.Printf("Incoming request:\n%s", requestDump)
 
-	responseBody := []byte(soapEmptyResponse())
-	response := &http.Response{
-		Status:        "200 OK",
-		StatusCode:    http.StatusOK,
-		Proto:         "HTTP/2.0",
-		ProtoMajor:    2,
-		ProtoMinor:    0,
-		Body:          io.NopCloser(bytes.NewReader(responseBody)),
-		ContentLength: int64(len(responseBody)),
-		Header:        make(http.Header),
-	}
-	// contentType := http.DetectContentType(responseBody)
-	response.Header.Set("Content-Type", "application/soap+xml")
+		err = ParseMessage(req.Body, handler)
+		if err != nil {
+			log.Printf("Failed to parse body: %s\n", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
 
-	responseDump, err := httputil.DumpResponse(response, true)
-	if err != nil {
-		log.Printf("Failed to dump outgoing response: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-	log.Printf("Outgoing response:\n%s", responseDump)
+		responseBody := []byte(soapEmptyResponse())
+		response := &http.Response{
+			Status:        "200 OK",
+			StatusCode:    http.StatusOK,
+			Proto:         "HTTP/2.0",
+			ProtoMajor:    2,
+			ProtoMinor:    0,
+			Body:          io.NopCloser(bytes.NewReader(responseBody)),
+			ContentLength: int64(len(responseBody)),
+			Header:        make(http.Header),
+		}
+		// contentType := http.DetectContentType(responseBody)
+		response.Header.Set("Content-Type", "application/soap+xml")
 
-	err = responseToWriter(w, response)
-	if err != nil {
-		log.Printf("Failed to send response: %v", err)
-		return
+		responseDump, err := httputil.DumpResponse(response, true)
+		if err != nil {
+			log.Printf("Failed to dump outgoing response: %v", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		log.Printf("Outgoing response:\n%s", responseDump)
+
+		err = responseToWriter(w, response)
+		if err != nil {
+			log.Printf("Failed to send response: %v", err)
+			return
+		}
 	}
 }
 

--- a/sdi/notification.go
+++ b/sdi/notification.go
@@ -1,0 +1,33 @@
+package sdi
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// ReceiptRejection represents the structure for "RicevutaScarto" message.
+type ReceiptRejection struct {
+	XMLName    xml.Name `xml:"RicevutaScarto"`
+	HashNumber string   `xml:"Hash"`
+	RejectionMessage
+}
+
+// ParseReceiptRejection converts XML to a Receipt Rejection structure
+func ParseReceiptRejection(receipt []byte) (ReceiptRejection, error) {
+	var rr ReceiptRejection
+	err := xml.Unmarshal(receipt, &rr)
+	if err != nil {
+		return rr, fmt.Errorf("xml parsing error: %v", err)
+	}
+
+	errors := rr.ErrorList.Error
+	if len(errors) > 0 {
+		errCodes := make([]string, len(errors))
+		for i, err := range errors {
+			errCodes[i] = err.Code
+		}
+		return rr, fmt.Errorf("sdi error code list: %v", errCodes)
+	}
+
+	return rr, nil
+}

--- a/sdi/notification_test.go
+++ b/sdi/notification_test.go
@@ -78,4 +78,99 @@ func TestParseReceiptRejection(t *testing.T) {
 		assert.Equal(t, 1, len(errors))
 		assert.Equal(t, "00102", errors[0].Code)
 	})
+
+	t.Run("should return many error codes", func(t *testing.T) {
+		//nolint:misspell
+		xml := `
+<?xml version="1.0" encoding="UTF-8"?>
+<ns3:RicevutaScarto
+  xmlns:ns3="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fattura/messaggi/v1.0"
+  xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" versione="1.0">
+  <IdentificativoSdI>10000001</IdentificativoSdI>
+  <NomeFile>IT01234567890_FPR01.xml</NomeFile>
+  <Hash>abc</Hash>
+  <DataOraRicezione>2024-06-12T12:00:00.000+02:00</DataOraRicezione>
+  <ListaErrori>
+    <Errore>
+      <Codice>00300</Codice>
+      <Descrizione>1.1.1.2 &lt;IdCodice&gt; non valido : 01234567890</Descrizione>
+      <Suggerimento>Verificare che il campo IdTrasmittente/IdCodice dei "DatiTrasmissione" sia
+        valido</Suggerimento>
+    </Errore>
+    <Errore>
+      <Codice>00301</Codice>
+      <Descrizione>1.2.1.1.2 &lt;IdCodice&gt; non valido : 01234567890</Descrizione>
+      <Suggerimento>Verificare che il campo IdFiscaleIVA/IdCodice del "CedentePrestatore" sia
+        valido</Suggerimento>
+    </Errore>
+    <Errore>
+      <Codice>00306</Codice>
+      <Descrizione>1.4.1.2 &lt;CodiceFiscale&gt; non valido : 09876543210</Descrizione>
+      <Suggerimento>Verificare che il campo Codice Fiscale del "CessionarioComittente" sia
+        valido</Suggerimento>
+    </Errore>
+    <Errore>
+      <Codice>00311</Codice>
+      <Descrizione>1.1.4 &lt;CodiceDestinatario&gt; non valido : Codice Destinatario B2B
+        ABC1234 non trovato</Descrizione>
+      <Suggerimento>Verificare il CodiceDestinatario: potrebbe non essere corretto o non
+        rientrare tra quelli previsti come codici di default</Suggerimento>
+    </Errore>
+  </ListaErrori>
+  <MessageId>100000002</MessageId>
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="Signature1">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
+      <ds:Reference Id="reference-document" URI="">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2002/06/xmldsig-filter2">
+            <XPath xmlns="http://www.w3.org/2002/06/xmldsig-filter2" Filter="subtract">
+              /descendant::ds:Signature</XPath>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+        <ds:DigestValue>esibfC13NOxGHvACM9xE+3vqc7S5l5jLiD6KrELvzMI=</ds:DigestValue>
+      </ds:Reference>
+      <ds:Reference Id="reference-signedpropeties"
+        Type="http://uri.etsi.org/01903#SignedProperties" URI="#SignedProperties_1">
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+        <ds:DigestValue>iOVs4LJ3TBKhs0Ez0fs686TRYtOoDODRYtF6JRgMBtI=</ds:DigestValue>
+      </ds:Reference>
+      <ds:Reference Id="reference-keyinfo" URI="#KeyInfoId">
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+        <ds:DigestValue>/+QgmHMrDlU2v1o7RBhHZJq1xNeRtA3Z7uYMpbMjoOE=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue Id="SignatureValue1"></ds:SignatureValue>
+    <ds:KeyInfo Id="KeyInfoId">
+      <ds:X509Data>
+        <ds:X509Certificate></ds:X509Certificate>
+      </ds:X509Data>
+    </ds:KeyInfo>
+    <ds:Object>
+      <xades:QualifyingProperties xmlns:xades="http://uri.etsi.org/01903/v1.3.2#"
+        Target="#Signature1">
+        <xades:SignedProperties Id="SignedProperties_1">
+          <xades:SignedSignatureProperties>
+            <xades:SigningTime>2024-06-12T12:00:00Z</xades:SigningTime>
+          </xades:SignedSignatureProperties>
+        </xades:SignedProperties>
+      </xades:QualifyingProperties>
+    </ds:Object>
+  </ds:Signature>
+</ns3:RicevutaScarto>
+`
+
+		output, err := sdi.ParseReceiptRejection([]byte(xml))
+		require.Error(t, err)
+		assert.Equal(t, fmt.Errorf("sdi error code list: [00300 00301 00306 00311]"), err)
+
+		errors := output.ErrorList.Error
+		assert.Equal(t, 4, len(errors))
+		assert.Equal(t, "00300", errors[0].Code)
+		assert.Equal(t, "00301", errors[1].Code)
+		assert.Equal(t, "00306", errors[2].Code)
+		assert.Equal(t, "00311", errors[3].Code)
+	})
 }

--- a/sdi/notification_test.go
+++ b/sdi/notification_test.go
@@ -1,0 +1,81 @@
+package sdi_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdi "github.com/invopop/gobl.fatturapa/sdi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseReceiptRejection(t *testing.T) {
+	t.Run("should return error code 00102 and info about an invalid signature in parsed struct", func(t *testing.T) {
+		//nolint:misspell
+		xml := `
+<?xml version="1.0" encoding="UTF-8"?>
+<ns3:RicevutaScarto
+  xmlns:ns3="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fattura/messaggi/v1.0"
+  xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" versione="1.0">
+  <IdentificativoSdI>12345678</IdentificativoSdI>
+  <NomeFile>IT01234567890_FPA01.xml</NomeFile>
+  <Hash>4672616374616c20536f667420697320636f6f6c21203f3f3f3f3f3f3f3f3f3f</Hash>
+  <DataOraRicezione>2024-06-11T16:00:00.000+00:00</DataOraRicezione>
+  <ListaErrori>
+    <Errore>
+      <Codice>00102</Codice>
+      <Descrizione>File non integro (firma non valida) : 00102&#13;</Descrizione>
+      <Suggerimento>Verificare che il file sia firmato correttamente o che non sia stato modificato dopo l'apposizione della firma</Suggerimento>
+    </Errore>
+  </ListaErrori>
+  <MessageId>100000000</MessageId>
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="Signature1">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
+      <ds:Reference Id="reference-document" URI="">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2002/06/xmldsig-filter2">
+            <XPath xmlns="http://www.w3.org/2002/06/xmldsig-filter2" Filter="subtract">/descendant::ds:Signature</XPath>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+        <ds:DigestValue>jCGMAK8UHIv+RiBwCKdGsLRSpKkDExW24eN5tSF0gNg=</ds:DigestValue>
+      </ds:Reference>
+      <ds:Reference Id="reference-signedpropeties" Type="http://uri.etsi.org/01903#SignedProperties" URI="#SignedProperties_1">
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+        <ds:DigestValue>Z...0=</ds:DigestValue>
+      </ds:Reference>
+      <ds:Reference Id="reference-keyinfo" URI="#KeyInfoId">
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+        <ds:DigestValue>/+Q...E=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue Id="SignatureValue1">SV...==</ds:SignatureValue>
+    <ds:KeyInfo Id="KeyInfoId">
+      <ds:X509Data>
+        <ds:X509Certificate>MIIF...M5</ds:X509Certificate>
+      </ds:X509Data>
+    </ds:KeyInfo>
+    <ds:Object>
+      <xades:QualifyingProperties xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" Target="#Signature1">
+        <xades:SignedProperties Id="SignedProperties_1">
+          <xades:SignedSignatureProperties>
+            <xades:SigningTime>2024-06-11T16:00:00Z</xades:SigningTime>
+          </xades:SignedSignatureProperties>
+        </xades:SignedProperties>
+      </xades:QualifyingProperties>
+    </ds:Object>
+  </ds:Signature>
+</ns3:RicevutaScarto>
+`
+
+		output, err := sdi.ParseReceiptRejection([]byte(xml))
+		require.Error(t, err)
+		assert.Equal(t, fmt.Errorf("sdi error code list: [00102]"), err)
+
+		errors := output.ErrorList.Error
+		assert.Equal(t, 1, len(errors))
+		assert.Equal(t, "00102", errors[0].Code)
+	})
+}

--- a/sdi/server.go
+++ b/sdi/server.go
@@ -1,0 +1,66 @@
+package sdi
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+// ServerConfig defines soap server configuration options
+type ServerConfig struct {
+	Host       string
+	Port       string
+	Verbose    bool
+	CACert     *x509.CertPool
+	CertAuth   tls.Certificate
+	ClientAuth tls.ClientAuthType
+}
+
+// RunServer sets up a server for receiving invoices from SdI
+func RunServer(config *ServerConfig, messageHandler http.HandlerFunc) error {
+	tlsConfig := &tls.Config{
+		ClientAuth:   config.ClientAuth,
+		ClientCAs:    config.CACert,
+		Certificates: []tls.Certificate{config.CertAuth},
+	}
+
+	server := http.Server{
+		Addr:      config.Host + ":" + config.Port,
+		Handler:   messageHandler,
+		TLSConfig: tlsConfig,
+	}
+
+	if err := http2.ConfigureServer(&server, &http2.Server{}); err != nil {
+		log.Fatalf("Failed to configure HTTP/2: %v", err)
+	}
+
+	go func() {
+		if err := server.ListenAndServeTLS("", ""); !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("HTTP server error: %v", err)
+		}
+		log.Println("Stopped serving new connections.")
+	}()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	shutdownCtx, shutdownRelease := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownRelease()
+
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		log.Fatalf("HTTP shutdown error: %v", err)
+	}
+	log.Println("Graceful shutdown complete.")
+
+	return nil
+}

--- a/sdi/test/examples/ESB85905495_00010_MT_001.xml
+++ b/sdi/test/examples/ESB85905495_00010_MT_001.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/' xmlns:typ='http://www.fatturapa.gov.it/sdi/ws/trasmissione/v1.0/types'>
+  <soapenv:Header/>
+	<soapenv:Body>
+		<ns3:MetadatiInvioFile xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" xmlns:ns3="http://www.fatturapa.gov.it/sdi/messaggi/v1.0" versione="1.0">
+			<IdentificativoSdI>29218239</IdentificativoSdI>
+			<NomeFile>ESB85905495_00010.xml</NomeFile>
+			<CodiceDestinatario>WSBKWM</CodiceDestinatario>
+			<Formato>FPA12</Formato>
+			<TentativiInvio>1</TentativiInvio>
+			<MessageId>176121330</MessageId>
+		</ns3:MetadatiInvioFile>
+	</soapenv:Body>
+</soapenv:Envelope>

--- a/sdi/test/examples/ESB85905495_00010_MT_004.xml
+++ b/sdi/test/examples/ESB85905495_00010_MT_004.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/' xmlns:typ='http://www.fatturapa.gov.it/sdi/ws/trasmissione/v1.0/types'>
+	<soapenv:Header/>
+	<soapenv:Body>
+		<ns3:NotificaMancataConsegna xmlns:ns3="http://www.fatturapa.gov.it/sdi/messaggi/v1.0" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" versione="1.0">
+			<IdentificativoSdI>29218239</IdentificativoSdI>
+			<NomeFile>ESB85905495_00010.xml</NomeFile>
+			<DataOraRicezione>2024-05-31T14:54:02.000+02:00</DataOraRicezione>
+			<Descrizione>Non è stato possibile recapitare la fattura/e al destinatario.Sono in corso le necessarie verifiche,al termine delle quali si procederà ad un nuovo tentativo di trasmissione. Si rimanda pertanto ad un momento successivo l'invio della ricevuta di consegna.</Descrizione>
+			<MessageId>176130653</MessageId>
+			<Note/>
+		</ns3:NotificaMancataConsegna>
+	</soapenv:Body>
+</soapenv:Envelope>

--- a/sdi/test/examples/ESB85905495_00010_MT_005.xml
+++ b/sdi/test/examples/ESB85905495_00010_MT_005.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/' xmlns:typ='http://www.fatturapa.gov.it/sdi/ws/trasmissione/v1.0/types'>
+	<soapenv:Header/>
+	<soapenv:Body>
+		<ns3:AttestazioneTrasmissioneFattura xmlns:ns3="http://www.fatturapa.gov.it/sdi/messaggi/v1.0" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" versione="1.0">
+			<IdentificativoSdI>29218239</IdentificativoSdI>
+			<NomeFile>ESB85905495_00010.xml</NomeFile>
+			<DataOraRicezione>2024-05-31T14:54:02.000+02:00</DataOraRicezione>
+			<Destinatario>
+				<Codice>WSBKWM</Codice>
+				<Descrizione>Amministrazione di test - Ufficio_test</Descrizione>
+			</Destinatario>
+			<MessageId>176197456</MessageId>
+			<Note>Fattura</Note>
+			<HashFileOriginale>bc0c40728a04f06d52412d946a939540583cbe0ea0edaa5c0ba8097fc0519d16</HashFileOriginale>
+		</ns3:AttestazioneTrasmissioneFattura>
+	</soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
## Pull Request Summary

A simple server whose purpose is to listen on a selected port for requests from SdI.

SdI uses TLS during communication. We can provide client auth type as an argument. We can ignore TLS in development, but in production it's probably impossible.

We also added handling of errors received after sending the invoice. We could check it live because SdI returned service unavailable.

## Feedback

I think that the next changes will mainly concern the message handler. Therefore, if there are no major comments, this PR will be worth merging and testing in production/test. Logs would be greatly appreciated.

Below are some logs from the local console commands.

```console
$ go run ./cmd/gobl.fatturapa help
Usage:
  gobl.fatturapa [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  convert     Convert a GOBL JSON into a FatturaPA XML
  help        Help about any command
  server      Server for communication with SdI in selected environment
  transmit    Transmit a FatturaPA XML file to SdI in selected environment
  version     

Flags:
  -h, --help   help for gobl.fatturapa

Use "gobl.fatturapa [command] --help" for more information about a command.
```

### Server

```console
$ go run ./cmd/gobl.fatturapa help server
Server for communication with SdI in selected environment

Usage:
  gobl.fatturapa server [host] [port] [flags]

Flags:
      --ca-cert string       Path to a file containing the CA certificate
      --cert string          Path to a file containing the certificate
      --client-auth string   Client authentication type (NoClientCert, RequestClientCert, RequireAnyClientCert, VerifyClientCertIfGiven, RequireAndVerifyClientCert) (default "RequireAndVerifyClientCert")
  -h, --help                 help for server
      --key string           Path to a file containing the certificate key
  -v, --verbose              Logs all requests into the console
```

Logs from the server startup and the simple request it received:

```console
$ go run ./cmd/gobl.fatturapa server --cert ./SDI-IT.INVOPOP.COM.pem --key ./key_server.key --ca-cert ./ca-all.pem --verbose sdi-it.invopop.com 8080
2024/06/04 23:00:23 Server start: sdi-it.invopop.com:8080
2024/06/04 23:00:23 Client auth: RequireAndVerifyClientCert
2024/06/04 23:00:35 Incoming request:
GET / HTTP/2.0
Host: sdi-it.invopop.com:8080
Accept: */*
User-Agent: curl/7.88.1

2024/06/04 23:00:35 Outgoing response:
HTTP/2.0 200 OK
Content-Length: 236
Content-Type: application/soap+xml

<?xml version='1.0' encoding='UTF-8'?><soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/' xmlns:typ='http://www.fatturapa.gov.it/sdi/ws/trasmissione/v1.0/types'><soapenv:Header/><soapenv:Body/></soapenv:Envelope>
^C
2024/06/04 23:00:41 Stopped serving new connections.
2024/06/04 23:00:41 Graceful shutdown complete.
```

Logs from the sent request (curl command):

```console
$ curl --cacert ./ca-all.pem --cert ./SDI-IT.INVOPOP.COM.pem --key ./key_server.key https://sdi-it.invopop.com:8080/
<?xml version='1.0' encoding='UTF-8'?><soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/' xmlns:typ='http://www.fatturapa.gov.it/sdi/ws/trasmissione/v1.0/types'><soapenv:Header/><soapenv:Body/></soapenv:Envelope>
```

Co-authored-by: @noplisu
Co-authored-by: @torrocus