### PR TITLE
Compare totals

### DIFF
--- a/body_in.go
+++ b/body_in.go
@@ -1,6 +1,7 @@
 package fatturapa
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -369,4 +370,23 @@ func parseSeriesAndCode(number string, series *cbc.Code, code *cbc.Code) {
 		*series = cbc.Code(parts[0])
 		*code = cbc.Code(parts[1])
 	}
+}
+
+// compareTotals compares the totals of the invoice with the totals of the FatturaPA document
+func compareTotals(inv *bill.Invoice, doc *GeneralDocumentData) error {
+	if inv == nil || doc == nil {
+		return nil
+	}
+	if doc.TotalAmount != "" {
+		fatturapaTotal, err := num.AmountFromString(doc.TotalAmount)
+		if err != nil {
+			return err
+		}
+
+		if fatturapaTotal.Compare(inv.Totals.Payable) != 0 {
+			return errors.New("totals do not match")
+		}
+	}
+
+	return nil
 }

--- a/body_in_test.go
+++ b/body_in_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
-	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
@@ -137,20 +136,12 @@ func TestBodyInConversion(t *testing.T) {
 
 	t.Run("should check totals are correct", func(t *testing.T) {
 		// Load the XML file
-		data, err := os.ReadFile(filepath.Join(test.GetDataPath(test.PathFatturaPAGOBL), "invoice-simple.xml"))
+		data, err := os.ReadFile(filepath.Join(test.GetDataPath(test.PathInvalid), "incorrect-total.xml"))
 		require.NoError(t, err)
 
 		// Convert XML to GOBL
 		env, err := test.ConvertToGOBL(data)
-		require.NoError(t, err)
-		require.NotNil(t, env)
-
-		// Extract the invoice
-		invoice, ok := env.Extract().(*bill.Invoice)
-		require.True(t, ok)
-		require.NotNil(t, invoice)
-
-		// Check totals
-		assert.Equal(t, num.MakeAmount(138840, 2), invoice.Totals.Payable)
+		require.Error(t, err, "totals do not match")
+		require.Nil(t, env)
 	})
 }

--- a/body_in_test.go
+++ b/body_in_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
@@ -132,5 +133,24 @@ func TestBodyInConversion(t *testing.T) {
 		if stampDuty, ok := invoice.Tax.Ext["it-sdi-stamp-duty"]; ok {
 			assert.Equal(t, cbc.Code("SI"), stampDuty)
 		}
+	})
+
+	t.Run("should check totals are correct", func(t *testing.T) {
+		// Load the XML file
+		data, err := os.ReadFile(filepath.Join(test.GetDataPath(test.PathFatturaPAGOBL), "invoice-simple.xml"))
+		require.NoError(t, err)
+
+		// Convert XML to GOBL
+		env, err := test.ConvertToGOBL(data)
+		require.NoError(t, err)
+		require.NotNil(t, env)
+
+		// Extract the invoice
+		invoice, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+		require.NotNil(t, invoice)
+
+		// Check totals
+		assert.Equal(t, num.MakeAmount(138840, 2), invoice.Totals.Payable)
 	})
 }

--- a/fatturapa.go
+++ b/fatturapa.go
@@ -14,6 +14,7 @@ import (
 	"github.com/invopop/gobl"
 	"github.com/invopop/gobl/addons/it/sdi"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/xmldsig"
 )
@@ -131,6 +132,16 @@ func Parse(doc []byte) (*gobl.Envelope, error) {
 
 	if err := env.Validate(); err != nil {
 		return nil, err
+	}
+
+	// Final totals check
+	fatturapaTotal, err := num.AmountFromString(d.Body[0].GeneralData.Document.TotalAmount)
+	if err != nil {
+		return nil, err
+	}
+
+	if fatturapaTotal.Compare(inv.Totals.Payable) != 0 {
+		return nil, errors.New("totals do not match")
 	}
 
 	return env, nil

--- a/fatturapa.go
+++ b/fatturapa.go
@@ -14,7 +14,6 @@ import (
 	"github.com/invopop/gobl"
 	"github.com/invopop/gobl/addons/it/sdi"
 	"github.com/invopop/gobl/bill"
-	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/xmldsig"
 )
@@ -135,13 +134,8 @@ func Parse(doc []byte) (*gobl.Envelope, error) {
 	}
 
 	// Final totals check
-	fatturapaTotal, err := num.AmountFromString(d.Body[0].GeneralData.Document.TotalAmount)
-	if err != nil {
+	if err := compareTotals(inv, d.Body[0].GeneralData.Document); err != nil {
 		return nil, err
-	}
-
-	if fatturapaTotal.Compare(inv.Totals.Payable) != 0 {
-		return nil, errors.New("totals do not match")
 	}
 
 	return env, nil

--- a/test/data/invalid/incorrect-total.xml
+++ b/test/data/invalid/incorrect-total.xml
@@ -1,0 +1,181 @@
+<p:FatturaElettronica xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" versione="FPA12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 https://www.fatturapa.gov.it/export/documenti/fatturapa/v1.2.2/Schema_del_file_xml_FatturaPA_v1.2.2.xsd">
+	<FatturaElettronicaHeader>
+		<DatiTrasmissione>
+			<IdTrasmittente>
+				<IdPaese>IT</IdPaese>
+				<IdCodice>01234567890</IdCodice>
+			</IdTrasmittente>
+			<ProgressivoInvio>019270f1</ProgressivoInvio>
+			<FormatoTrasmissione>FPA12</FormatoTrasmissione>
+			<CodiceDestinatario>0000000</CodiceDestinatario>
+		</DatiTrasmissione>
+		<CedentePrestatore>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>12345678903</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>Hotel California</Denominazione>
+				</Anagrafica>
+				<RegimeFiscale>RF01</RegimeFiscale>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>Via California</Indirizzo>
+				<NumeroCivico>102</NumeroCivico>
+				<CAP>33213</CAP>
+				<Comune>Palermo</Comune>
+				<Provincia>PA</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+			<IscrizioneREA>
+				<Ufficio>RM</Ufficio>
+				<NumeroREA>123456</NumeroREA>
+				<StatoLiquidazione>LN</StatoLiquidazione>
+			</IscrizioneREA>
+			<Contatti></Contatti>
+		</CedentePrestatore>
+		<CessionarioCommittente>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>13029381004</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>Mela S.r.l.</Denominazione>
+				</Anagrafica>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>Via dei Mille</Indirizzo>
+				<NumeroCivico>23</NumeroCivico>
+				<CAP>00100</CAP>
+				<Comune>Firenze</Comune>
+				<Provincia>FI</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+		</CessionarioCommittente>
+	</FatturaElettronicaHeader>
+	<FatturaElettronicaBody>
+		<DatiGenerali>
+			<DatiGeneraliDocumento>
+				<TipoDocumento>TD01</TipoDocumento>
+				<Divisa>EUR</Divisa>
+				<Data>2024-10-09</Data>
+				<Numero>SAMPLE-002</Numero>
+				<ImportoTotaleDocumento>288.00</ImportoTotaleDocumento>
+			</DatiGeneraliDocumento>
+			<DatiOrdineAcquisto>
+				<IdDocumento>ORDINECLI</IdDocumento>
+				<CodiceCIG>ZB98B4A235</CodiceCIG>
+			</DatiOrdineAcquisto>
+		</DatiGenerali>
+		<DatiBeniServizi>
+			<DettaglioLinee>
+				<NumeroLinea>1</NumeroLinea>
+				<Descrizione>Tassa di Soggiorno</Descrizione>
+				<Quantita>1.00</Quantita>
+				<PrezzoUnitario>1.00</PrezzoUnitario>
+				<PrezzoTotale>1.00</PrezzoTotale>
+				<AliquotaIVA>0.00</AliquotaIVA>
+				<Natura>N1</Natura>
+			</DettaglioLinee>
+			<DettaglioLinee>
+				<NumeroLinea>2</NumeroLinea>
+				<Descrizione>Camera Matrimoniale</Descrizione>
+				<Quantita>2.00</Quantita>
+				<PrezzoUnitario>125.00</PrezzoUnitario>
+				<ScontoMaggiorazione>
+					<Tipo>SC</Tipo>
+					<Importo>5.0000</Importo>
+				</ScontoMaggiorazione>
+				<PrezzoTotale>240.00</PrezzoTotale>
+				<AliquotaIVA>10.00</AliquotaIVA>
+			</DettaglioLinee>
+			<DatiRiepilogo>
+				<AliquotaIVA>0.00</AliquotaIVA>
+				<Natura>N1</Natura>
+				<ImponibileImporto>1.00</ImponibileImporto>
+				<Imposta>0.00</Imposta>
+				<RiferimentoNormativo>Escluse ex. art. 15 del D.P.R. 633/1972</RiferimentoNormativo>
+			</DatiRiepilogo>
+			<DatiRiepilogo>
+				<AliquotaIVA>10.00</AliquotaIVA>
+				<ImponibileImporto>240.00</ImponibileImporto>
+				<Imposta>24.00</Imposta>
+			</DatiRiepilogo>
+		</DatiBeniServizi>
+		<DatiPagamento>
+			<CondizioniPagamento>TP03</CondizioniPagamento>
+			<DettaglioPagamento>
+				<ModalitaPagamento>MP08</ModalitaPagamento>
+				<DataRiferimentoTerminiPagamento>2023-05-01</DataRiferimentoTerminiPagamento>
+				<ImportoPagamento>265.00</ImportoPagamento>
+			</DettaglioPagamento>
+		</DatiPagamento>
+	</FatturaElettronicaBody>
+	<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="Signature-019270f1-b0d8-7299-85ca-0a595a9ee9c7-Signature">
+		<ds:SignedInfo>
+			<ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"></ds:CanonicalizationMethod>
+			<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"></ds:SignatureMethod>
+			<ds:Reference Id="Reference-019270f1-b0d8-7299-85ca-0a595a9ee9c7" Type="http://www.w3.org/2000/09/xmldsig#Object" URI="">
+				<ds:Transforms>
+					<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>
+				</ds:Transforms>
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>oST9FvH6bUVc5nBde6qqh6BUkAumuiPdCjNlYZoLFbijQcG9dQf53G9AIpRtwMzlZYs+PQKbedNAJcWHQ6sKdA==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference URI="#Certificate-019270f1-b0d8-7299-85ca-0a595a9ee9c7">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>3q7QB/qpmhOHMCJ7AEgv4KrbfrbBoFHcIKNLAfzxqedFrAGW3UcGRnf0Jd85FIDGN7ZxXnQxnPh9Fh15iqDk2A==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#Signature-019270f1-b0d8-7299-85ca-0a595a9ee9c7-SignedProperties">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>Shhbwzjk3MuDUvtuifIn5xVoKCNYbX4cD+UsFNh5rYQHTCR0RknL7kj7j/6RI/8cUlt2hVDadESTYc01KpwQZQ==</ds:DigestValue>
+			</ds:Reference>
+		</ds:SignedInfo>
+		<ds:SignatureValue Id="Signature-019270f1-b0d8-7299-85ca-0a595a9ee9c7-SignatureValue">SP2+U7k9sPUraZHrgMLsd8RWhndlYT/PDb6Ph/U2Qs9zdTBLqcFjnIJhQ914ejCS5bSd0A/tpvLCDkqjlElJTUajxI81RuVFEZUPSonhgHuQ/uoRqAgcUbaALv610pXhSlXXm90yVO5ePP1wXt7/EQ/PfUOmEGpdF8Dejw4Yg8+mS5EE11MO2Zg5FVOvUwwR+9AnI7o6N8myo8Q00mMLLMxrdpbDMJsVRjBP11dpm09VLr+29paM9at+cv0XgAUoixfl1UpYP5ifzNqmiBShPTsNIsKsXityUrfoBY6Dfntw1qUMvdjQtzjCjvSo+QG4xC+V7uisxFKQEIhVAOKpig==</ds:SignatureValue>
+		<ds:KeyInfo Id="Certificate-019270f1-b0d8-7299-85ca-0a595a9ee9c7">
+			<ds:X509Data>
+				<ds:X509Certificate>MIIHhjCCBm6gAwIBAgIQSOSlyjvRFUlfo/hUFNAvqDANBgkqhkiG9w0BAQsFADBLMQswCQYDVQQGEwJFUzERMA8GA1UECgwIRk5NVC1SQ00xDjAMBgNVBAsMBUNlcmVzMRkwFwYDVQQDDBBBQyBGTk1UIFVzdWFyaW9zMB4XDTIwMTEwNTEzMDQyMFoXDTI0MTEwNTEzMDQyMFowgYUxCzAJBgNVBAYTAkVTMRgwFgYDVQQFEw9JRENFUy05OTk5OTk5OVIxEDAOBgNVBCoMB1BSVUVCQVMxGjAYBgNVBAQMEUVJREFTIENFUlRJRklDQURPMS4wLAYDVQQDDCVFSURBUyBDRVJUSUZJQ0FETyBQUlVFQkFTIC0gOTk5OTk5OTlSMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQIDAQABo4IEKTCCBCUwgZIGA1UdEQSBijCBh4Edc29wb3J0ZV90ZWNuaWNvX2NlcmVzQGZubXQuZXOkZjBkMRgwFgYJKwYBBAGsZgEEDAk5OTk5OTk5OVIxGjAYBgkrBgEEAaxmAQMMC0NFUlRJRklDQURPMRQwEgYJKwYBBAGsZgECDAVFSURBUzEWMBQGCSsGAQQBrGYBAQwHUFJVRUJBUzAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIF4DAdBgNVHSUEFjAUBggrBgEFBQcDBAYIKwYBBQUHAwIwHQYDVR0OBBYEFE5aHiQQRwVYJzmmkfG/i5MxmMNdMB8GA1UdIwQYMBaAFLHUT8QjefpEBQnG6znP6DWwuCBkMIGCBggrBgEFBQcBAQR2MHQwPQYIKwYBBQUHMAGGMWh0dHA6Ly9vY3NwdXN1LmNlcnQuZm5tdC5lcy9vY3NwdXN1L09jc3BSZXNwb25kZXIwMwYIKwYBBQUHMAKGJ2h0dHA6Ly93d3cuY2VydC5mbm10LmVzL2NlcnRzL0FDVVNVLmNydDCCARUGA1UdIASCAQwwggEIMIH6BgorBgEEAaxmAwoBMIHrMCkGCCsGAQUFBwIBFh1odHRwOi8vd3d3LmNlcnQuZm5tdC5lcy9kcGNzLzCBvQYIKwYBBQUHAgIwgbAMga1DZXJ0aWZpY2FkbyBjdWFsaWZpY2FkbyBkZSBmaXJtYSBlbGVjdHLDs25pY2EuIFN1amV0byBhIGxhcyBjb25kaWNpb25lcyBkZSB1c28gZXhwdWVzdGFzIGVuIGxhIERQQyBkZSBsYSBGTk1ULVJDTSBjb24gTklGOiBRMjgyNjAwNC1KIChDL0pvcmdlIEp1YW4gMTA2LTI4MDA5LU1hZHJpZC1Fc3Bhw7FhKTAJBgcEAIvsQAEAMIG6BggrBgEFBQcBAwSBrTCBqjAIBgYEAI5GAQEwCwYGBACORgEDAgEPMBMGBgQAjkYBBjAJBgcEAI5GAQYBMHwGBgQAjkYBBTByMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lcy5wZGYTAmVzMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lbi5wZGYTAmVuMIG1BgNVHR8Ega0wgaowgaeggaSggaGGgZ5sZGFwOi8vbGRhcHVzdS5jZXJ0LmZubXQuZXMvY249Q1JMMzc0OCxjbj1BQyUyMEZOTVQlMjBVc3VhcmlvcyxvdT1DRVJFUyxvPUZOTVQtUkNNLGM9RVM/Y2VydGlmaWNhdGVSZXZvY2F0aW9uTGlzdDtiaW5hcnk/YmFzZT9vYmplY3RjbGFzcz1jUkxEaXN0cmlidXRpb25Qb2ludDANBgkqhkiG9w0BAQsFAAOCAQEAH4t5/v/SLsm/dXRDw4QblCmTX+5pgXJ+4G1Lb3KTSPtDJ0UbQiAMUx+iqDDOoMHU5H7po/HZLJXgNwvKLoiLbl5/q6Mqasif87fa6awNkuz/Y6dvXw0UOJh+Ud/Wrk0EyaP9ZtrLVsraUOobNyS6g+lOrCxRrNxGRK2yAeotO6LEo1y3b7CB+Amd2jDq8lY3AtCYlrhuCaTf0AD9IBYYmigHzFD/VH5a8uG95l6J85FQG7tMsG6UQHFM2EmNhpbrYH+ihetz3UhzcC5Fd/P1X7pGBymQgbCyBjCRf/HEVzyoHL72uMp2I4JXX4v8HABZT8xtlDY4LE0am9keJhaNcg==</ds:X509Certificate>
+			</ds:X509Data>
+			<ds:KeyValue>
+				<ds:RSAKeyValue>
+					<ds:Modulus>ujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQ==</ds:Modulus>
+					<ds:Exponent>AQAB</ds:Exponent>
+				</ds:RSAKeyValue>
+			</ds:KeyValue>
+		</ds:KeyInfo>
+		<ds:Object>
+			<xades:QualifyingProperties xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" Id="Signature-019270f1-b0d8-7299-85ca-0a595a9ee9c7-QualifyingProperties" Target="#Signature-019270f1-b0d8-7299-85ca-0a595a9ee9c7-Signature">
+				<xades:SignedProperties Id="Signature-019270f1-b0d8-7299-85ca-0a595a9ee9c7-SignedProperties">
+					<xades:SignedSignatureProperties>
+						<xades:SigningTime>2022-02-01T04:00:00+00:00</xades:SigningTime>
+						<xades:SigningCertificate>
+							<xades:Cert>
+								<xades:CertDigest>
+									<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+									<ds:DigestValue>VmNYwDiCBBXJX/IL1AUYj7uHouM2Jcp3ZkeqmB+FKGTTwXIIZnCWmZVhCSB7uNoV6Xee7nZVkMqeCMQk3tGR0g==</ds:DigestValue>
+								</xades:CertDigest>
+								<xades:IssuerSerial>
+									<ds:X509IssuerName>CN=AC FNMT Usuarios,OU=Ceres,O=FNMT-RCM,C=ES</ds:X509IssuerName>
+									<ds:X509SerialNumber>96891622000445695554354105786026700712</ds:X509SerialNumber>
+								</xades:IssuerSerial>
+							</xades:Cert>
+						</xades:SigningCertificate>
+					</xades:SignedSignatureProperties>
+					<xades:SignedDataObjectProperties>
+						<xades:DataObjectFormat ObjectReference="#Reference-019270f1-b0d8-7299-85ca-0a595a9ee9c7">
+							<xades:Description>Fattura PA</xades:Description>
+							<xades:ObjectIdentifier>
+								<xades:Identifier Qualifier="OIDAsURN">urn:oid:1.2.840.10003.5.109.10</xades:Identifier>
+								<xades:Description></xades:Description>
+							</xades:ObjectIdentifier>
+							<xades:MimeType>text/xml</xades:MimeType>
+							<xades:Encoding></xades:Encoding>
+						</xades:DataObjectFormat>
+					</xades:SignedDataObjectProperties>
+				</xades:SignedProperties>
+			</xades:QualifyingProperties>
+		</ds:Object>
+	</ds:Signature>
+</p:FatturaElettronica>

--- a/test/test.go
+++ b/test/test.go
@@ -31,6 +31,9 @@ const (
 
 	// PathFatturaPAGOBL is the path to the test data for the FatturaPA GOBL
 	PathFatturaPAGOBL = "fatturapa.gobl"
+
+	// PathInvalid is the path to the test data for the invalid FatturaPA
+	PathInvalid = "invalid"
 )
 
 // UpdateOut is a flag that can be set to update example files in test/data and test/data/out


### PR DESCRIPTION
Add check to compare totals. Returns error if they do not match. 

Need the empty string check as num.AmountFromString returns an error on empty string. We skip in this case as the total is simply not present so we assume our total is correct. This can occur as FatturaPA does not force the total at invoice level.