### PR TITLE
Add period date and reverse charge N2.1 support to line items

### DIFF
--- a/items.go
+++ b/items.go
@@ -21,6 +21,8 @@ type LineDetail struct {
 	Description      string             `xml:"Descrizione"`
 	Quantity         string             `xml:"Quantita"`
 	Unit             string             `xml:"UnitaMisura,omitempty"`
+	PeriodStart      string             `xml:"DataInizioPeriodo,omitempty"`
+	PeriodEnd        string             `xml:"DataFinePeriodo,omitempty"`
 	UnitPrice        string             `xml:"PrezzoUnitario"`
 	PriceAdjustments []*PriceAdjustment `xml:"ScontoMaggiorazione,omitempty"`
 	TotalPrice       string             `xml:"PrezzoTotale"`
@@ -70,6 +72,11 @@ func generateLineDetails(inv *bill.Invoice) []*LineDetail {
 			UnitPrice:        formatAmount8(&lp),
 			TotalPrice:       formatAmount8(line.Total),
 			PriceAdjustments: extractLinePriceAdjustments(line),
+		}
+
+		if line.Period != nil {
+			d.PeriodStart = line.Period.Start.String()
+			d.PeriodEnd = line.Period.End.String()
 		}
 
 		// Process taxes

--- a/items.go
+++ b/items.go
@@ -9,6 +9,12 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+const (
+	naturaN21               = "N2.1"
+	tipoDatoINVCONT         = "INVCONT"
+	riferimentoTestoINVCONT = "Inversione contabile - art. 21 c.6 bis lett. a) DPR 633/72"
+)
+
 // GoodsServices contains all data related to the goods and services sold.
 type GoodsServices struct {
 	LineDetails []*LineDetail `xml:"DettaglioLinee"`
@@ -29,6 +35,15 @@ type LineDetail struct {
 	TaxRate          string             `xml:"AliquotaIVA"`
 	Retained         string             `xml:"Ritenuta,omitempty"`
 	TaxNature        string             `xml:"Natura,omitempty"`
+	OtherData        []*OtherData       `xml:"AltriDatiGestionali,omitempty"`
+}
+
+// OtherData contains additional management data for a line item.
+type OtherData struct {
+	DataType      string `xml:"TipoDato"`
+	TextReference string `xml:"RiferimentoTesto,omitempty"`
+	NumReference  string `xml:"RiferimentoNumero,omitempty"`
+	DateReference string `xml:"RiferimentoData,omitempty"`
 }
 
 // TaxSummary contains tax summary data such as tax rate, tax amount, etc.
@@ -75,22 +90,31 @@ func generateLineDetails(inv *bill.Invoice) []*LineDetail {
 		}
 
 		if line.Period != nil {
-			d.PeriodStart = line.Period.Start.String()
-			d.PeriodEnd = line.Period.End.String()
+			if !line.Period.Start.IsZero() {
+				d.PeriodStart = line.Period.Start.String()
+			}
+			if !line.Period.End.IsZero() {
+				d.PeriodEnd = line.Period.End.String()
+			}
 		}
 
-		// Process taxes
-		if len(line.Taxes) > 0 {
-			// Process all taxes in a single loop
-			for _, t := range line.Taxes {
-				// Handle VAT tax
-				if t.Category == tax.CategoryVAT {
-					d.TaxRate = formatPercentageWithZero(t.Percent)
-					d.TaxNature = exemptExtensionCode(t.Ext)
-				} else if t.Ext != nil && t.Ext.Has(sdi.ExtKeyRetained) {
-					// Check for retained taxes
-					d.Retained = flagSI
-				}
+		// Set VAT fields from the VAT combo on the line
+		if vat := line.Taxes.Get(tax.CategoryVAT); vat != nil {
+			d.TaxRate = formatPercentageWithZero(vat.Percent)
+			d.TaxNature = exemptExtensionCode(vat.Ext)
+			if d.TaxNature == naturaN21 && inv.HasTags(tax.TagReverseCharge) {
+				d.OtherData = append(d.OtherData, &OtherData{
+					DataType:      tipoDatoINVCONT,
+					TextReference: riferimentoTestoINVCONT,
+				})
+			}
+		}
+
+		// Check for retained taxes
+		for _, t := range line.Taxes {
+			if t.Ext != nil && t.Ext.Has(sdi.ExtKeyRetained) {
+				d.Retained = flagSI
+				break
 			}
 		}
 

--- a/items_parse.go
+++ b/items_parse.go
@@ -83,15 +83,20 @@ func goblBillInvoiceAddLineDetails(inv *bill.Invoice, lineDetails []*LineDetail,
 
 		// Add period dates
 		if detail.PeriodStart != "" || detail.PeriodEnd != "" {
-			start, err := parseDate(detail.PeriodStart)
-			if err != nil {
-				return fmt.Errorf("parsing period start: %w", err)
+			p := &cal.Period{}
+			if detail.PeriodStart != "" {
+				p.Start, err = parseDate(detail.PeriodStart)
+				if err != nil {
+					return fmt.Errorf("parsing period start: %w", err)
+				}
 			}
-			end, err := parseDate(detail.PeriodEnd)
-			if err != nil {
-				return fmt.Errorf("parsing period end: %w", err)
+			if detail.PeriodEnd != "" {
+				p.End, err = parseDate(detail.PeriodEnd)
+				if err != nil {
+					return fmt.Errorf("parsing period end: %w", err)
+				}
 			}
-			line.Period = &cal.Period{Start: start, End: end}
+			line.Period = p
 		}
 
 		// Add unit. Add to description if unit is invalid
@@ -114,6 +119,14 @@ func goblBillInvoiceAddLineDetails(inv *bill.Invoice, lineDetails []*LineDetail,
 		}
 		if vatCombo != nil {
 			line.Taxes = append(line.Taxes, vatCombo)
+		}
+
+		// Check for INVCONT in AltriDatiGestionali
+		for _, od := range detail.OtherData {
+			if od.DataType == tipoDatoINVCONT {
+				inv.SetTags(tax.TagReverseCharge)
+				break
+			}
 		}
 
 		// Add line to invoice

--- a/items_parse.go
+++ b/items_parse.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/invopop/gobl/addons/it/sdi"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
@@ -78,6 +79,19 @@ func goblBillInvoiceAddLineDetails(inv *bill.Invoice, lineDetails []*LineDetail,
 				Name:  detail.Description,
 				Price: &unitPrice,
 			},
+		}
+
+		// Add period dates
+		if detail.PeriodStart != "" || detail.PeriodEnd != "" {
+			start, err := parseDate(detail.PeriodStart)
+			if err != nil {
+				return fmt.Errorf("parsing period start: %w", err)
+			}
+			end, err := parseDate(detail.PeriodEnd)
+			if err != nil {
+				return fmt.Errorf("parsing period end: %w", err)
+			}
+			line.Period = &cal.Period{Start: start, End: end}
 		}
 
 		// Add unit. Add to description if unit is invalid

--- a/items_parse_test.go
+++ b/items_parse_test.go
@@ -204,3 +204,18 @@ func TestItemsInConversion(t *testing.T) {
 		assert.Equal(t, cbc.Code("I"), rate2.Ext[sdi.ExtKeyRetained])
 	})
 }
+
+func TestINVCONTInConversion(t *testing.T) {
+	t.Run("should set reverse-charge tag when INVCONT is present", func(t *testing.T) {
+		data, err := os.ReadFile(filepath.Join(test.GetDataPath(test.PathFatturaPAGOBL), "invoice-reverse-charge.xml"))
+		require.NoError(t, err)
+
+		env, err := test.ConvertToGOBL(data)
+		require.NoError(t, err)
+		require.NotNil(t, env)
+
+		invoice, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+		assert.True(t, invoice.HasTags(tax.TagReverseCharge))
+	})
+}

--- a/items_test.go
+++ b/items_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/invopop/gobl.fatturapa/test"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/num"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,6 +54,44 @@ func TestDettaglioLineePeriod(t *testing.T) {
 		dl2 := doc.Body[0].GoodsServices.LineDetails[1]
 		assert.Empty(t, dl2.PeriodStart)
 		assert.Empty(t, dl2.PeriodEnd)
+	})
+
+	t.Run("should omit missing period date", func(t *testing.T) {
+		env := test.LoadTestFile("invoice-services-period.json", test.PathGOBLFatturaPA)
+		test.ModifyInvoice(env, func(inv *bill.Invoice) {
+			inv.Lines[0].Period.End = cal.Date{}
+		})
+		doc, err := test.ConvertFromGOBL(env)
+		require.NoError(t, err)
+
+		dl := doc.Body[0].GoodsServices.LineDetails[0]
+		assert.Equal(t, "2024-01-01", dl.PeriodStart)
+		assert.Empty(t, dl.PeriodEnd)
+	})
+}
+
+func TestAltriDatiGestionaliINVCONT(t *testing.T) {
+	t.Run("should add INVCONT for N2.1 with reverse-charge tag", func(t *testing.T) {
+		env := test.LoadTestFile("invoice-reverse-charge.json", test.PathGOBLFatturaPA)
+		doc, err := test.ConvertFromGOBL(env)
+		require.NoError(t, err)
+
+		for _, dl := range doc.Body[0].GoodsServices.LineDetails {
+			require.Len(t, dl.OtherData, 1)
+			assert.Equal(t, "INVCONT", dl.OtherData[0].DataType)
+			assert.Equal(t, "Inversione contabile - art. 21 c.6 bis lett. a) DPR 633/72", dl.OtherData[0].TextReference)
+		}
+	})
+
+	t.Run("should not add INVCONT for N2.1 without reverse-charge tag", func(t *testing.T) {
+		env := test.LoadTestFile("invoice-hotel.json", test.PathGOBLFatturaPA)
+		doc, err := test.ConvertFromGOBL(env)
+		require.NoError(t, err)
+
+		// First line has N2.1 but no reverse-charge tag on the invoice
+		dl := doc.Body[0].GoodsServices.LineDetails[0]
+		assert.Equal(t, "N2.1", dl.TaxNature)
+		assert.Empty(t, dl.OtherData)
 	})
 }
 

--- a/items_test.go
+++ b/items_test.go
@@ -39,6 +39,23 @@ func TestDettaglioLinee(t *testing.T) {
 	})
 }
 
+func TestDettaglioLineePeriod(t *testing.T) {
+	t.Run("should map period dates from GOBL to FatturaPA", func(t *testing.T) {
+		env := test.LoadTestFile("invoice-services-period.json", test.PathGOBLFatturaPA)
+		doc, err := test.ConvertFromGOBL(env)
+		require.NoError(t, err)
+
+		dl := doc.Body[0].GoodsServices.LineDetails[0]
+		assert.Equal(t, "2024-01-01", dl.PeriodStart)
+		assert.Equal(t, "2024-01-31", dl.PeriodEnd)
+
+		// Line without period should have empty dates
+		dl2 := doc.Body[0].GoodsServices.LineDetails[1]
+		assert.Empty(t, dl2.PeriodStart)
+		assert.Empty(t, dl2.PeriodEnd)
+	})
+}
+
 func TestDatiRiepilogo(t *testing.T) {
 	t.Run("should contain the tax summary info", func(t *testing.T) {
 		env := test.LoadTestFile("invoice-simple.json", test.PathGOBLFatturaPA)

--- a/test/data/fatturapa.gobl/invoice-reverse-charge.xml
+++ b/test/data/fatturapa.gobl/invoice-reverse-charge.xml
@@ -1,0 +1,109 @@
+<p:FatturaElettronica xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" versione="FPR12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 https://www.fatturapa.gov.it/export/documenti/fatturapa/v1.2.2/Schema_del_file_xml_FatturaPA_v1.2.2.xsd">
+	<FatturaElettronicaHeader>
+		<DatiTrasmissione>
+			<IdTrasmittente>
+				<IdPaese>IT</IdPaese>
+				<IdCodice>01234567890</IdCodice>
+			</IdTrasmittente>
+			<ProgressivoInvio>679a2f25</ProgressivoInvio>
+			<FormatoTrasmissione>FPR12</FormatoTrasmissione>
+			<CodiceDestinatario>XXXXXXX</CodiceDestinatario>
+		</DatiTrasmissione>
+		<CedentePrestatore>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>12345678903</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>Tech Solutions S.r.l.</Denominazione>
+				</Anagrafica>
+				<RegimeFiscale>RF01</RegimeFiscale>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>Via Roma</Indirizzo>
+				<NumeroCivico>15</NumeroCivico>
+				<CAP>20100</CAP>
+				<Comune>Milano</Comune>
+				<Provincia>MI</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+		</CedentePrestatore>
+		<CessionarioCommittente>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>DE</IdPaese>
+					<IdCodice>111111125</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>Acme GmbH</Denominazione>
+				</Anagrafica>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>Friedrichstrasse</Indirizzo>
+				<NumeroCivico>10</NumeroCivico>
+				<CAP>10117</CAP>
+				<Comune>Berlin</Comune>
+				<Nazione>DE</Nazione>
+			</Sede>
+		</CessionarioCommittente>
+	</FatturaElettronicaHeader>
+	<FatturaElettronicaBody>
+		<DatiGenerali>
+			<DatiGeneraliDocumento>
+				<TipoDocumento>TD01</TipoDocumento>
+				<Divisa>EUR</Divisa>
+				<Data>2024-02-15</Data>
+				<Numero>SAMPLE-010</Numero>
+				<ImportoTotaleDocumento>2300.00</ImportoTotaleDocumento>
+			</DatiGeneraliDocumento>
+		</DatiGenerali>
+		<DatiBeniServizi>
+			<DettaglioLinee>
+				<NumeroLinea>1</NumeroLinea>
+				<Descrizione>Development services</Descrizione>
+				<Quantita>20.00</Quantita>
+				<UnitaMisura>h</UnitaMisura>
+				<PrezzoUnitario>90.00</PrezzoUnitario>
+				<PrezzoTotale>1800.00</PrezzoTotale>
+				<AliquotaIVA>0.00</AliquotaIVA>
+				<Natura>N2.1</Natura>
+				<AltriDatiGestionali>
+					<TipoDato>INVCONT</TipoDato>
+					<RiferimentoTesto>Inversione contabile - art. 21 c.6 bis lett. a) DPR 633/72</RiferimentoTesto>
+				</AltriDatiGestionali>
+			</DettaglioLinee>
+			<DettaglioLinee>
+				<NumeroLinea>2</NumeroLinea>
+				<Descrizione>Consulting services</Descrizione>
+				<Quantita>1.00</Quantita>
+				<UnitaMisura>h</UnitaMisura>
+				<PrezzoUnitario>500.00</PrezzoUnitario>
+				<PrezzoTotale>500.00</PrezzoTotale>
+				<AliquotaIVA>0.00</AliquotaIVA>
+				<Natura>N2.1</Natura>
+				<AltriDatiGestionali>
+					<TipoDato>INVCONT</TipoDato>
+					<RiferimentoTesto>Inversione contabile - art. 21 c.6 bis lett. a) DPR 633/72</RiferimentoTesto>
+				</AltriDatiGestionali>
+			</DettaglioLinee>
+			<DatiRiepilogo>
+				<AliquotaIVA>0.00</AliquotaIVA>
+				<Natura>N2.1</Natura>
+				<ImponibileImporto>2300.00</ImponibileImporto>
+				<Imposta>0.00</Imposta>
+				<RiferimentoNormativo>Non soggette ex. art. 7 del D.P.R. 633/72</RiferimentoNormativo>
+			</DatiRiepilogo>
+		</DatiBeniServizi>
+		<DatiPagamento>
+			<CondizioniPagamento>TP02</CondizioniPagamento>
+			<DettaglioPagamento>
+				<ModalitaPagamento>MP05</ModalitaPagamento>
+				<ImportoPagamento>2300.00</ImportoPagamento>
+				<IstitutoFinanziario>BANCA POPOLARE DI MILANO</IstitutoFinanziario>
+				<IBAN>IT60X0542811101000000123456</IBAN>
+				<BIC>BCITITMM</BIC>
+			</DettaglioPagamento>
+		</DatiPagamento>
+	</FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/test/data/fatturapa.gobl/invoice-services-period.xml
+++ b/test/data/fatturapa.gobl/invoice-services-period.xml
@@ -1,0 +1,97 @@
+<p:FatturaElettronica xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" versione="FPR12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 https://www.fatturapa.gov.it/export/documenti/fatturapa/v1.2.2/Schema_del_file_xml_FatturaPA_v1.2.2.xsd">
+	<FatturaElettronicaHeader>
+		<DatiTrasmissione>
+			<IdTrasmittente>
+				<IdPaese>IT</IdPaese>
+				<IdCodice>01234567890</IdCodice>
+			</IdTrasmittente>
+			<ProgressivoInvio>679a2f25</ProgressivoInvio>
+			<FormatoTrasmissione>FPR12</FormatoTrasmissione>
+			<CodiceDestinatario>ABCDEF1</CodiceDestinatario>
+		</DatiTrasmissione>
+		<CedentePrestatore>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>12345678903</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>MªF. Services</Denominazione>
+				</Anagrafica>
+				<RegimeFiscale>RF02</RegimeFiscale>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>VIALE DELLA LIBERTÀ</Indirizzo>
+				<NumeroCivico>1</NumeroCivico>
+				<CAP>00100</CAP>
+				<Comune>ROMA</Comune>
+				<Provincia>RM</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+		</CedentePrestatore>
+		<CessionarioCommittente>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>09876543217</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>MARIO LEONI</Denominazione>
+				</Anagrafica>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>VIALE DELI LAVORATORI</Indirizzo>
+				<NumeroCivico>32</NumeroCivico>
+				<CAP>50100</CAP>
+				<Comune>FIRENZE</Comune>
+				<Provincia>FI</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+		</CessionarioCommittente>
+	</FatturaElettronicaHeader>
+	<FatturaElettronicaBody>
+		<DatiGenerali>
+			<DatiGeneraliDocumento>
+				<TipoDocumento>TD06</TipoDocumento>
+				<Divisa>EUR</Divisa>
+				<Data>2023-03-02</Data>
+				<Numero>SAMPLE-001</Numero>
+				<ImportoTotaleDocumento>2806.00</ImportoTotaleDocumento>
+			</DatiGeneraliDocumento>
+		</DatiGenerali>
+		<DatiBeniServizi>
+			<DettaglioLinee>
+				<NumeroLinea>1</NumeroLinea>
+				<Descrizione>Development services</Descrizione>
+				<Quantita>20.00</Quantita>
+				<UnitaMisura>h</UnitaMisura>
+				<DataInizioPeriodo>2024-01-01</DataInizioPeriodo>
+				<DataFinePeriodo>2024-01-31</DataFinePeriodo>
+				<PrezzoUnitario>90.00</PrezzoUnitario>
+				<PrezzoTotale>1800.00</PrezzoTotale>
+				<AliquotaIVA>22.00</AliquotaIVA>
+			</DettaglioLinee>
+			<DettaglioLinee>
+				<NumeroLinea>2</NumeroLinea>
+				<Descrizione>Consulting services</Descrizione>
+				<Quantita>1.00</Quantita>
+				<UnitaMisura>h</UnitaMisura>
+				<PrezzoUnitario>500.00</PrezzoUnitario>
+				<PrezzoTotale>500.00</PrezzoTotale>
+				<AliquotaIVA>22.00</AliquotaIVA>
+			</DettaglioLinee>
+			<DatiRiepilogo>
+				<AliquotaIVA>22.00</AliquotaIVA>
+				<ImponibileImporto>2300.00</ImponibileImporto>
+				<Imposta>506.00</Imposta>
+			</DatiRiepilogo>
+		</DatiBeniServizi>
+		<DatiPagamento>
+			<CondizioniPagamento>TP02</CondizioniPagamento>
+			<DettaglioPagamento>
+				<ModalitaPagamento>MP08</ModalitaPagamento>
+				<ImportoPagamento>2806.00</ImportoPagamento>
+			</DettaglioPagamento>
+		</DatiPagamento>
+	</FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/test/data/fatturapa.gobl/out/invoice-reverse-charge.json
+++ b/test/data/fatturapa.gobl/out/invoice-reverse-charge.json
@@ -1,0 +1,148 @@
+{
+	"$regime": "IT",
+	"$addons": [
+		"it-sdi-v1"
+	],
+	"$tags": [
+		"reverse-charge"
+	],
+	"uuid": "00000000-0000-0000-0000-000000000000",
+	"type": "standard",
+	"code": "SAMPLE-010",
+	"issue_date": "2024-02-15",
+	"currency": "EUR",
+	"tax": {
+		"ext": {
+			"it-sdi-document-type": "TD01",
+			"it-sdi-format": "FPR12"
+		}
+	},
+	"supplier": {
+		"name": "Tech Solutions S.r.l.",
+		"tax_id": {
+			"country": "IT",
+			"code": "12345678903"
+		},
+		"addresses": [
+			{
+				"num": "15",
+				"street": "Via Roma",
+				"locality": "Milano",
+				"region": "MI",
+				"code": "20100",
+				"country": "IT"
+			}
+		],
+		"ext": {
+			"it-sdi-fiscal-regime": "RF01"
+		}
+	},
+	"customer": {
+		"name": "Acme GmbH",
+		"tax_id": {
+			"country": "DE",
+			"code": "111111125"
+		},
+		"addresses": [
+			{
+				"num": "10",
+				"street": "Friedrichstrasse",
+				"locality": "Berlin",
+				"country": "DE"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "20.00",
+			"item": {
+				"name": "Development services",
+				"price": "90.00",
+				"unit": "h"
+			},
+			"sum": "1800.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "outside-scope",
+					"ext": {
+						"it-sdi-exempt": "N2.1"
+					}
+				}
+			],
+			"total": "1800.00"
+		},
+		{
+			"i": 2,
+			"quantity": "1.00",
+			"item": {
+				"name": "Consulting services",
+				"price": "500.00",
+				"unit": "h"
+			},
+			"sum": "500.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "outside-scope",
+					"ext": {
+						"it-sdi-exempt": "N2.1"
+					}
+				}
+			],
+			"total": "500.00"
+		}
+	],
+	"payment": {
+		"terms": {
+			"key": "pending"
+		},
+		"instructions": {
+			"key": "credit-transfer",
+			"credit_transfer": [
+				{
+					"iban": "IT60X0542811101000000123456",
+					"bic": "BCITITMM",
+					"name": "BANCA POPOLARE DI MILANO"
+				}
+			],
+			"ext": {
+				"it-sdi-payment-means": "MP05"
+			}
+		}
+	},
+	"totals": {
+		"sum": "2300.00",
+		"total": "2300.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "outside-scope",
+							"ext": {
+								"it-sdi-exempt": "N2.1"
+							},
+							"base": "2300.00",
+							"amount": "0.00"
+						}
+					],
+					"amount": "0.00"
+				}
+			],
+			"sum": "0.00"
+		},
+		"tax": "0.00",
+		"total_with_tax": "2300.00",
+		"payable": "2300.00"
+	},
+	"notes": [
+		{
+			"key": "legal",
+			"src": "reverse-charge",
+			"text": "Reverse Charge / Inversione del soggetto passivo"
+		}
+	]
+}

--- a/test/data/fatturapa.gobl/out/invoice-services-period.json
+++ b/test/data/fatturapa.gobl/out/invoice-services-period.json
@@ -1,0 +1,140 @@
+{
+	"$regime": "IT",
+	"$addons": [
+		"it-sdi-v1"
+	],
+	"$tags": [
+		"freelance"
+	],
+	"uuid": "00000000-0000-0000-0000-000000000000",
+	"type": "standard",
+	"code": "SAMPLE-001",
+	"issue_date": "2023-03-02",
+	"currency": "EUR",
+	"tax": {
+		"ext": {
+			"it-sdi-document-type": "TD06",
+			"it-sdi-format": "FPR12"
+		}
+	},
+	"supplier": {
+		"name": "MªF. Services",
+		"tax_id": {
+			"country": "IT",
+			"code": "12345678903"
+		},
+		"addresses": [
+			{
+				"num": "1",
+				"street": "VIALE DELLA LIBERTÀ",
+				"locality": "ROMA",
+				"region": "RM",
+				"code": "00100",
+				"country": "IT"
+			}
+		],
+		"ext": {
+			"it-sdi-fiscal-regime": "RF02"
+		}
+	},
+	"customer": {
+		"name": "MARIO LEONI",
+		"tax_id": {
+			"country": "IT",
+			"code": "09876543217"
+		},
+		"inboxes": [
+			{
+				"key": "it-sdi-code",
+				"code": "ABCDEF1"
+			}
+		],
+		"addresses": [
+			{
+				"num": "32",
+				"street": "VIALE DELI LAVORATORI",
+				"locality": "FIRENZE",
+				"region": "FI",
+				"code": "50100",
+				"country": "IT"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "20.00",
+			"period": {
+				"start": "2024-01-01",
+				"end": "2024-01-31"
+			},
+			"item": {
+				"name": "Development services",
+				"price": "90.00",
+				"unit": "h"
+			},
+			"sum": "1800.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"percent": "22.00%"
+				}
+			],
+			"total": "1800.00"
+		},
+		{
+			"i": 2,
+			"quantity": "1.00",
+			"item": {
+				"name": "Consulting services",
+				"price": "500.00",
+				"unit": "h"
+			},
+			"sum": "500.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"percent": "22.00%"
+				}
+			],
+			"total": "500.00"
+		}
+	],
+	"payment": {
+		"terms": {
+			"key": "pending"
+		},
+		"instructions": {
+			"key": "card",
+			"ext": {
+				"it-sdi-payment-means": "MP08"
+			}
+		}
+	},
+	"totals": {
+		"sum": "2300.00",
+		"total": "2300.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "standard",
+							"base": "2300.00",
+							"percent": "22.00%",
+							"amount": "506.00"
+						}
+					],
+					"amount": "506.00"
+				}
+			],
+			"sum": "506.00"
+		},
+		"tax": "506.00",
+		"total_with_tax": "2806.00",
+		"payable": "2806.00"
+	}
+}

--- a/test/data/gobl.fatturapa/invoice-reverse-charge.json
+++ b/test/data/gobl.fatturapa/invoice-reverse-charge.json
@@ -1,0 +1,163 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "679a2f25-7483-11ec-9722-7ea2cb436ff6",
+		"dig": {
+			"alg": "sha256",
+			"val": "256b8fdbb909680c3649f955efea6ce714a949fe96f9b74afc565d97586d00cd"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "IT",
+		"$addons": [
+			"it-sdi-v1"
+		],
+		"$tags": [
+			"reverse-charge"
+		],
+		"uuid": "0190c0ec-8109-756b-a4f0-88c4b542ab6f",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "010",
+		"issue_date": "2024-02-15",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"it-sdi-document-type": "TD01",
+				"it-sdi-format": "FPR12"
+			}
+		},
+		"supplier": {
+			"name": "Tech Solutions S.r.l.",
+			"tax_id": {
+				"country": "IT",
+				"code": "12345678903"
+			},
+			"addresses": [
+				{
+					"num": "15",
+					"street": "Via Roma",
+					"locality": "Milano",
+					"region": "MI",
+					"code": "20100",
+					"country": "IT"
+				}
+			],
+			"registration": {
+				"currency": "EUR",
+				"office": "MI",
+				"entry": "123456"
+			},
+			"ext": {
+				"it-sdi-fiscal-regime": "RF01"
+			}
+		},
+		"customer": {
+			"name": "Acme GmbH",
+			"tax_id": {
+				"country": "DE",
+				"code": "111111125"
+			},
+			"addresses": [
+				{
+					"num": "10",
+					"street": "Friedrichstrasse",
+					"locality": "Berlin",
+					"code": "10117",
+					"country": "DE"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "outside-scope",
+						"ext": {
+							"it-sdi-exempt": "N2.1"
+						}
+					}
+				],
+				"total": "1800.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Consulting services",
+					"price": "500.00",
+					"unit": "h"
+				},
+				"sum": "500.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "outside-scope",
+						"ext": {
+							"it-sdi-exempt": "N2.1"
+						}
+					}
+				],
+				"total": "500.00"
+			}
+		],
+		"payment": {
+			"instructions": {
+				"key": "credit-transfer",
+				"credit_transfer": [
+					{
+						"iban": "IT60X0542811101000000123456",
+						"bic": "BCITITMM",
+						"name": "BANCA POPOLARE DI MILANO"
+					}
+				],
+				"ext": {
+					"it-sdi-payment-means": "MP05"
+				}
+			}
+		},
+		"totals": {
+			"sum": "2300.00",
+			"total": "2300.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "outside-scope",
+								"ext": {
+									"it-sdi-exempt": "N2.1"
+								},
+								"base": "2300.00",
+								"amount": "0.00"
+							}
+						],
+						"amount": "0.00"
+					}
+				],
+				"sum": "0.00"
+			},
+			"tax": "0.00",
+			"total_with_tax": "2300.00",
+			"payable": "2300.00"
+		},
+		"notes": [
+			{
+				"key": "legal",
+				"src": "reverse-charge",
+				"text": "Reverse Charge / Inversione del soggetto passivo"
+			}
+		]
+	}
+}

--- a/test/data/gobl.fatturapa/invoice-services-period.json
+++ b/test/data/gobl.fatturapa/invoice-services-period.json
@@ -1,0 +1,189 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "679a2f25-7483-11ec-9722-7ea2cb436ff6",
+		"dig": {
+			"alg": "sha256",
+			"val": "d2a53caa955d92f7f36cf0ff4f15468ce383e7f51b41b3b3a86cd35cc87e4a7a"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "IT",
+		"$addons": [
+			"it-sdi-v1"
+		],
+		"$tags": [
+			"freelance"
+		],
+		"uuid": "0190c0ec-8109-756b-a4f0-88c4b542ab6e",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2023-03-02",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"it-sdi-document-type": "TD06",
+				"it-sdi-format": "FPR12"
+			}
+		},
+		"supplier": {
+			"name": "MªF. Services",
+			"tax_id": {
+				"country": "IT",
+				"code": "12345678903"
+			},
+			"people": [
+				{
+					"name": {
+						"given": "GIANCARLO",
+						"surname": "ROSSI"
+					}
+				}
+			],
+			"addresses": [
+				{
+					"num": "1",
+					"street": "VIALE DELLA LIBERTÀ",
+					"locality": "ROMA",
+					"region": "RM",
+					"code": "00100",
+					"country": "IT"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			],
+			"telephones": [
+				{
+					"num": "999999999"
+				}
+			],
+			"registration": {
+				"capital": "50000.00",
+				"currency": "EUR",
+				"office": "RM",
+				"entry": "123456"
+			},
+			"ext": {
+				"it-sdi-fiscal-regime": "RF02"
+			}
+		},
+		"customer": {
+			"name": "MARIO LEONI",
+			"tax_id": {
+				"country": "IT",
+				"code": "09876543217"
+			},
+			"people": [
+				{
+					"name": {
+						"prefix": "Dott.",
+						"given": "MARIO",
+						"surname": "LEONI"
+					}
+				}
+			],
+			"inboxes": [
+				{
+					"key": "it-sdi-code",
+					"code": "ABCDEF1"
+				}
+			],
+			"addresses": [
+				{
+					"num": "32",
+					"street": "VIALE DELI LAVORATORI",
+					"locality": "FIRENZE",
+					"region": "FI",
+					"code": "50100",
+					"country": "IT"
+				}
+			],
+			"emails": [
+				{
+					"addr": "leoni@mario.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"period": {
+					"start": "2024-01-01",
+					"end": "2024-01-31"
+				},
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "22.0%"
+					}
+				],
+				"total": "1800.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Consulting services",
+					"price": "500.00",
+					"unit": "h"
+				},
+				"sum": "500.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "22.0%"
+					}
+				],
+				"total": "500.00"
+			}
+		],
+		"payment": {
+			"instructions": {
+				"key": "card",
+				"ext": {
+					"it-sdi-payment-means": "MP08"
+				}
+			}
+		},
+		"totals": {
+			"sum": "2300.00",
+			"total": "2300.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "2300.00",
+								"percent": "22.0%",
+								"amount": "506.00"
+							}
+						],
+						"amount": "506.00"
+					}
+				],
+				"sum": "506.00"
+			},
+			"tax": "506.00",
+			"total_with_tax": "2806.00",
+			"payable": "2806.00"
+		}
+	}
+}

--- a/test/data/gobl.fatturapa/out/invoice-reverse-charge.xml
+++ b/test/data/gobl.fatturapa/out/invoice-reverse-charge.xml
@@ -1,0 +1,180 @@
+<p:FatturaElettronica xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" versione="FPR12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 https://www.fatturapa.gov.it/export/documenti/fatturapa/v1.2.2/Schema_del_file_xml_FatturaPA_v1.2.2.xsd">
+	<FatturaElettronicaHeader>
+		<DatiTrasmissione>
+			<IdTrasmittente>
+				<IdPaese>IT</IdPaese>
+				<IdCodice>01234567890</IdCodice>
+			</IdTrasmittente>
+			<ProgressivoInvio>679a2f25</ProgressivoInvio>
+			<FormatoTrasmissione>FPR12</FormatoTrasmissione>
+			<CodiceDestinatario>XXXXXXX</CodiceDestinatario>
+		</DatiTrasmissione>
+		<CedentePrestatore>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>12345678903</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>Tech Solutions S.r.l.</Denominazione>
+				</Anagrafica>
+				<RegimeFiscale>RF01</RegimeFiscale>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>Via Roma</Indirizzo>
+				<NumeroCivico>15</NumeroCivico>
+				<CAP>20100</CAP>
+				<Comune>Milano</Comune>
+				<Provincia>MI</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+			<IscrizioneREA>
+				<Ufficio>MI</Ufficio>
+				<NumeroREA>123456</NumeroREA>
+				<StatoLiquidazione>LN</StatoLiquidazione>
+			</IscrizioneREA>
+			<Contatti></Contatti>
+		</CedentePrestatore>
+		<CessionarioCommittente>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>DE</IdPaese>
+					<IdCodice>111111125</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>Acme GmbH</Denominazione>
+				</Anagrafica>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>Friedrichstrasse</Indirizzo>
+				<NumeroCivico>10</NumeroCivico>
+				<CAP>00000</CAP>
+				<Comune>Berlin</Comune>
+				<Nazione>DE</Nazione>
+			</Sede>
+		</CessionarioCommittente>
+	</FatturaElettronicaHeader>
+	<FatturaElettronicaBody>
+		<DatiGenerali>
+			<DatiGeneraliDocumento>
+				<TipoDocumento>TD01</TipoDocumento>
+				<Divisa>EUR</Divisa>
+				<Data>2024-02-15</Data>
+				<Numero>SAMPLE-010</Numero>
+				<ImportoTotaleDocumento>2300.00</ImportoTotaleDocumento>
+			</DatiGeneraliDocumento>
+		</DatiGenerali>
+		<DatiBeniServizi>
+			<DettaglioLinee>
+				<NumeroLinea>1</NumeroLinea>
+				<Descrizione>Development services</Descrizione>
+				<Quantita>20.00</Quantita>
+				<UnitaMisura>h</UnitaMisura>
+				<PrezzoUnitario>90.00</PrezzoUnitario>
+				<PrezzoTotale>1800.00</PrezzoTotale>
+				<AliquotaIVA>0.00</AliquotaIVA>
+				<Natura>N2.1</Natura>
+				<AltriDatiGestionali>
+					<TipoDato>INVCONT</TipoDato>
+					<RiferimentoTesto>Inversione contabile - art. 21 c.6 bis lett. a) DPR 633/72</RiferimentoTesto>
+				</AltriDatiGestionali>
+			</DettaglioLinee>
+			<DettaglioLinee>
+				<NumeroLinea>2</NumeroLinea>
+				<Descrizione>Consulting services</Descrizione>
+				<Quantita>1.00</Quantita>
+				<UnitaMisura>h</UnitaMisura>
+				<PrezzoUnitario>500.00</PrezzoUnitario>
+				<PrezzoTotale>500.00</PrezzoTotale>
+				<AliquotaIVA>0.00</AliquotaIVA>
+				<Natura>N2.1</Natura>
+				<AltriDatiGestionali>
+					<TipoDato>INVCONT</TipoDato>
+					<RiferimentoTesto>Inversione contabile - art. 21 c.6 bis lett. a) DPR 633/72</RiferimentoTesto>
+				</AltriDatiGestionali>
+			</DettaglioLinee>
+			<DatiRiepilogo>
+				<AliquotaIVA>0.00</AliquotaIVA>
+				<Natura>N2.1</Natura>
+				<ImponibileImporto>2300.00</ImponibileImporto>
+				<Imposta>0.00</Imposta>
+				<RiferimentoNormativo>Non soggette ex. art. 7 del D.P.R. 633/72</RiferimentoNormativo>
+			</DatiRiepilogo>
+		</DatiBeniServizi>
+		<DatiPagamento>
+			<CondizioniPagamento>TP02</CondizioniPagamento>
+			<DettaglioPagamento>
+				<ModalitaPagamento>MP05</ModalitaPagamento>
+				<ImportoPagamento>2300.00</ImportoPagamento>
+				<IstitutoFinanziario>BANCA POPOLARE DI MILANO</IstitutoFinanziario>
+				<IBAN>IT60X0542811101000000123456</IBAN>
+				<BIC>BCITITMM</BIC>
+			</DettaglioPagamento>
+		</DatiPagamento>
+	</FatturaElettronicaBody>
+	<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-Signature">
+		<ds:SignedInfo>
+			<ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"></ds:CanonicalizationMethod>
+			<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"></ds:SignatureMethod>
+			<ds:Reference Id="Reference-679a2f25-7483-11ec-9722-7ea2cb436ff6" Type="http://www.w3.org/2000/09/xmldsig#Object" URI="">
+				<ds:Transforms>
+					<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>
+				</ds:Transforms>
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>JEM6zqdnpglO/uGYf+LYbsBZ3TAXE/fomiJ5zFWFgXlkzPCj8PsL3sa6CT4tskNhYBBoexlESl3CfurZxwc0Rw==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference URI="#Certificate-679a2f25-7483-11ec-9722-7ea2cb436ff6">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>6+b9KJiVX/kpy7+O7yI2sGdhrxIlXzoDNTq47UDlH9Pkx7IKuEmt6cmyCYAvblLsWfllzb0LQVhi5TGvh3wWLw==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-SignedProperties">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>7Tj/Vr2iDe5KuUvZfrT8ntgjkAtz6zIeztpC/liVkbigGbZLGFHcMpSsVtsRc+WIqqwsB7AwFVjqjSIKIDI3uw==</ds:DigestValue>
+			</ds:Reference>
+		</ds:SignedInfo>
+		<ds:SignatureValue Id="Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-SignatureValue">RCAU7LB88cNzq/CTJcWF/HshZNTeEvwWvG2CQGak4fDjJNr5Ds1SHraaOPHgJFalo8b0eO/zRws9oZpwfueFXvO1k+7hX0PJFKSrUys7iHCWQAdiwGWCdEWYPn+g5k90CfaYYMrPXnolFakIQcDhrDTXH2GW6UxyzCzyNVTXZ4FGYWHQwBji3SfSLi3eSQgTJ7X2vqF+VgvNf7tZH4WHuZuA1GFNezJsdJwkBleyrtpm5f4YsgfKdmDBCWfv1tmpADJdjlPaoofg18tCvChOL9MrHM7LCwQUx2N+eVjiGmLDfHGsadwHqnDlFKJlgQcvQb6+6AM1sWZdb06EBsg9wA==</ds:SignatureValue>
+		<ds:KeyInfo Id="Certificate-679a2f25-7483-11ec-9722-7ea2cb436ff6">
+			<ds:X509Data>
+				<ds:X509Certificate>MIIHhjCCBm6gAwIBAgIQSOSlyjvRFUlfo/hUFNAvqDANBgkqhkiG9w0BAQsFADBLMQswCQYDVQQGEwJFUzERMA8GA1UECgwIRk5NVC1SQ00xDjAMBgNVBAsMBUNlcmVzMRkwFwYDVQQDDBBBQyBGTk1UIFVzdWFyaW9zMB4XDTIwMTEwNTEzMDQyMFoXDTI0MTEwNTEzMDQyMFowgYUxCzAJBgNVBAYTAkVTMRgwFgYDVQQFEw9JRENFUy05OTk5OTk5OVIxEDAOBgNVBCoMB1BSVUVCQVMxGjAYBgNVBAQMEUVJREFTIENFUlRJRklDQURPMS4wLAYDVQQDDCVFSURBUyBDRVJUSUZJQ0FETyBQUlVFQkFTIC0gOTk5OTk5OTlSMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQIDAQABo4IEKTCCBCUwgZIGA1UdEQSBijCBh4Edc29wb3J0ZV90ZWNuaWNvX2NlcmVzQGZubXQuZXOkZjBkMRgwFgYJKwYBBAGsZgEEDAk5OTk5OTk5OVIxGjAYBgkrBgEEAaxmAQMMC0NFUlRJRklDQURPMRQwEgYJKwYBBAGsZgECDAVFSURBUzEWMBQGCSsGAQQBrGYBAQwHUFJVRUJBUzAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIF4DAdBgNVHSUEFjAUBggrBgEFBQcDBAYIKwYBBQUHAwIwHQYDVR0OBBYEFE5aHiQQRwVYJzmmkfG/i5MxmMNdMB8GA1UdIwQYMBaAFLHUT8QjefpEBQnG6znP6DWwuCBkMIGCBggrBgEFBQcBAQR2MHQwPQYIKwYBBQUHMAGGMWh0dHA6Ly9vY3NwdXN1LmNlcnQuZm5tdC5lcy9vY3NwdXN1L09jc3BSZXNwb25kZXIwMwYIKwYBBQUHMAKGJ2h0dHA6Ly93d3cuY2VydC5mbm10LmVzL2NlcnRzL0FDVVNVLmNydDCCARUGA1UdIASCAQwwggEIMIH6BgorBgEEAaxmAwoBMIHrMCkGCCsGAQUFBwIBFh1odHRwOi8vd3d3LmNlcnQuZm5tdC5lcy9kcGNzLzCBvQYIKwYBBQUHAgIwgbAMga1DZXJ0aWZpY2FkbyBjdWFsaWZpY2FkbyBkZSBmaXJtYSBlbGVjdHLDs25pY2EuIFN1amV0byBhIGxhcyBjb25kaWNpb25lcyBkZSB1c28gZXhwdWVzdGFzIGVuIGxhIERQQyBkZSBsYSBGTk1ULVJDTSBjb24gTklGOiBRMjgyNjAwNC1KIChDL0pvcmdlIEp1YW4gMTA2LTI4MDA5LU1hZHJpZC1Fc3Bhw7FhKTAJBgcEAIvsQAEAMIG6BggrBgEFBQcBAwSBrTCBqjAIBgYEAI5GAQEwCwYGBACORgEDAgEPMBMGBgQAjkYBBjAJBgcEAI5GAQYBMHwGBgQAjkYBBTByMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lcy5wZGYTAmVzMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lbi5wZGYTAmVuMIG1BgNVHR8Ega0wgaowgaeggaSggaGGgZ5sZGFwOi8vbGRhcHVzdS5jZXJ0LmZubXQuZXMvY249Q1JMMzc0OCxjbj1BQyUyMEZOTVQlMjBVc3VhcmlvcyxvdT1DRVJFUyxvPUZOTVQtUkNNLGM9RVM/Y2VydGlmaWNhdGVSZXZvY2F0aW9uTGlzdDtiaW5hcnk/YmFzZT9vYmplY3RjbGFzcz1jUkxEaXN0cmlidXRpb25Qb2ludDANBgkqhkiG9w0BAQsFAAOCAQEAH4t5/v/SLsm/dXRDw4QblCmTX+5pgXJ+4G1Lb3KTSPtDJ0UbQiAMUx+iqDDOoMHU5H7po/HZLJXgNwvKLoiLbl5/q6Mqasif87fa6awNkuz/Y6dvXw0UOJh+Ud/Wrk0EyaP9ZtrLVsraUOobNyS6g+lOrCxRrNxGRK2yAeotO6LEo1y3b7CB+Amd2jDq8lY3AtCYlrhuCaTf0AD9IBYYmigHzFD/VH5a8uG95l6J85FQG7tMsG6UQHFM2EmNhpbrYH+ihetz3UhzcC5Fd/P1X7pGBymQgbCyBjCRf/HEVzyoHL72uMp2I4JXX4v8HABZT8xtlDY4LE0am9keJhaNcg==</ds:X509Certificate>
+			</ds:X509Data>
+			<ds:KeyValue>
+				<ds:RSAKeyValue>
+					<ds:Modulus>ujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQ==</ds:Modulus>
+					<ds:Exponent>AQAB</ds:Exponent>
+				</ds:RSAKeyValue>
+			</ds:KeyValue>
+		</ds:KeyInfo>
+		<ds:Object>
+			<xades:QualifyingProperties xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" Id="Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-QualifyingProperties" Target="#Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-Signature">
+				<xades:SignedProperties Id="Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-SignedProperties">
+					<xades:SignedSignatureProperties>
+						<xades:SigningTime>2022-02-01T04:00:00+00:00</xades:SigningTime>
+						<xades:SigningCertificate>
+							<xades:Cert>
+								<xades:CertDigest>
+									<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+									<ds:DigestValue>VmNYwDiCBBXJX/IL1AUYj7uHouM2Jcp3ZkeqmB+FKGTTwXIIZnCWmZVhCSB7uNoV6Xee7nZVkMqeCMQk3tGR0g==</ds:DigestValue>
+								</xades:CertDigest>
+								<xades:IssuerSerial>
+									<ds:X509IssuerName>CN=AC FNMT Usuarios,OU=Ceres,O=FNMT-RCM,C=ES</ds:X509IssuerName>
+									<ds:X509SerialNumber>96891622000445695554354105786026700712</ds:X509SerialNumber>
+								</xades:IssuerSerial>
+							</xades:Cert>
+						</xades:SigningCertificate>
+					</xades:SignedSignatureProperties>
+					<xades:SignedDataObjectProperties>
+						<xades:DataObjectFormat ObjectReference="#Reference-679a2f25-7483-11ec-9722-7ea2cb436ff6">
+							<xades:Description>Fattura PA</xades:Description>
+							<xades:ObjectIdentifier>
+								<xades:Identifier Qualifier="OIDAsURN">urn:oid:1.2.840.10003.5.109.10</xades:Identifier>
+								<xades:Description></xades:Description>
+							</xades:ObjectIdentifier>
+							<xades:MimeType>text/xml</xades:MimeType>
+							<xades:Encoding></xades:Encoding>
+						</xades:DataObjectFormat>
+					</xades:SignedDataObjectProperties>
+				</xades:SignedProperties>
+			</xades:QualifyingProperties>
+		</ds:Object>
+	</ds:Signature>
+</p:FatturaElettronica>

--- a/test/data/gobl.fatturapa/out/invoice-services-period.xml
+++ b/test/data/gobl.fatturapa/out/invoice-services-period.xml
@@ -1,0 +1,172 @@
+<p:FatturaElettronica xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" versione="FPR12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 https://www.fatturapa.gov.it/export/documenti/fatturapa/v1.2.2/Schema_del_file_xml_FatturaPA_v1.2.2.xsd">
+	<FatturaElettronicaHeader>
+		<DatiTrasmissione>
+			<IdTrasmittente>
+				<IdPaese>IT</IdPaese>
+				<IdCodice>01234567890</IdCodice>
+			</IdTrasmittente>
+			<ProgressivoInvio>679a2f25</ProgressivoInvio>
+			<FormatoTrasmissione>FPR12</FormatoTrasmissione>
+			<CodiceDestinatario>ABCDEF1</CodiceDestinatario>
+		</DatiTrasmissione>
+		<CedentePrestatore>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>12345678903</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>MªF. Services</Denominazione>
+				</Anagrafica>
+				<RegimeFiscale>RF02</RegimeFiscale>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>VIALE DELLA LIBERTÀ</Indirizzo>
+				<NumeroCivico>1</NumeroCivico>
+				<CAP>00100</CAP>
+				<Comune>ROMA</Comune>
+				<Provincia>RM</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+			<IscrizioneREA>
+				<Ufficio>RM</Ufficio>
+				<NumeroREA>123456</NumeroREA>
+				<CapitaleSociale>50000.00</CapitaleSociale>
+				<StatoLiquidazione>LN</StatoLiquidazione>
+			</IscrizioneREA>
+			<Contatti>
+				<Telefono>999999999</Telefono>
+				<Email>billing@example.com</Email>
+			</Contatti>
+		</CedentePrestatore>
+		<CessionarioCommittente>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>09876543217</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>MARIO LEONI</Denominazione>
+				</Anagrafica>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>VIALE DELI LAVORATORI</Indirizzo>
+				<NumeroCivico>32</NumeroCivico>
+				<CAP>50100</CAP>
+				<Comune>FIRENZE</Comune>
+				<Provincia>FI</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+		</CessionarioCommittente>
+	</FatturaElettronicaHeader>
+	<FatturaElettronicaBody>
+		<DatiGenerali>
+			<DatiGeneraliDocumento>
+				<TipoDocumento>TD06</TipoDocumento>
+				<Divisa>EUR</Divisa>
+				<Data>2023-03-02</Data>
+				<Numero>SAMPLE-001</Numero>
+				<ImportoTotaleDocumento>2806.00</ImportoTotaleDocumento>
+			</DatiGeneraliDocumento>
+		</DatiGenerali>
+		<DatiBeniServizi>
+			<DettaglioLinee>
+				<NumeroLinea>1</NumeroLinea>
+				<Descrizione>Development services</Descrizione>
+				<Quantita>20.00</Quantita>
+				<UnitaMisura>h</UnitaMisura>
+				<DataInizioPeriodo>2024-01-01</DataInizioPeriodo>
+				<DataFinePeriodo>2024-01-31</DataFinePeriodo>
+				<PrezzoUnitario>90.00</PrezzoUnitario>
+				<PrezzoTotale>1800.00</PrezzoTotale>
+				<AliquotaIVA>22.00</AliquotaIVA>
+			</DettaglioLinee>
+			<DettaglioLinee>
+				<NumeroLinea>2</NumeroLinea>
+				<Descrizione>Consulting services</Descrizione>
+				<Quantita>1.00</Quantita>
+				<UnitaMisura>h</UnitaMisura>
+				<PrezzoUnitario>500.00</PrezzoUnitario>
+				<PrezzoTotale>500.00</PrezzoTotale>
+				<AliquotaIVA>22.00</AliquotaIVA>
+			</DettaglioLinee>
+			<DatiRiepilogo>
+				<AliquotaIVA>22.00</AliquotaIVA>
+				<ImponibileImporto>2300.00</ImponibileImporto>
+				<Imposta>506.00</Imposta>
+			</DatiRiepilogo>
+		</DatiBeniServizi>
+		<DatiPagamento>
+			<CondizioniPagamento>TP02</CondizioniPagamento>
+			<DettaglioPagamento>
+				<ModalitaPagamento>MP08</ModalitaPagamento>
+				<ImportoPagamento>2806.00</ImportoPagamento>
+			</DettaglioPagamento>
+		</DatiPagamento>
+	</FatturaElettronicaBody>
+	<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-Signature">
+		<ds:SignedInfo>
+			<ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"></ds:CanonicalizationMethod>
+			<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"></ds:SignatureMethod>
+			<ds:Reference Id="Reference-679a2f25-7483-11ec-9722-7ea2cb436ff6" Type="http://www.w3.org/2000/09/xmldsig#Object" URI="">
+				<ds:Transforms>
+					<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>
+				</ds:Transforms>
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>sA8PgLotrcv5u+3RWsrRMqfaOqMY7QGoQf6yL4QuALDurTPIxkHU/0x1NV4V1AEKSvGjlFSLDoKRI9Tp8h0IHg==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference URI="#Certificate-679a2f25-7483-11ec-9722-7ea2cb436ff6">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>6+b9KJiVX/kpy7+O7yI2sGdhrxIlXzoDNTq47UDlH9Pkx7IKuEmt6cmyCYAvblLsWfllzb0LQVhi5TGvh3wWLw==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-SignedProperties">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>7Tj/Vr2iDe5KuUvZfrT8ntgjkAtz6zIeztpC/liVkbigGbZLGFHcMpSsVtsRc+WIqqwsB7AwFVjqjSIKIDI3uw==</ds:DigestValue>
+			</ds:Reference>
+		</ds:SignedInfo>
+		<ds:SignatureValue Id="Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-SignatureValue">R281Ugn6XGD+KYBbcjDaEDHO7Ixt+LvuhN9HAMJqOm7sGU/AMvWSzxF/U631pG+irGR+BnzpuOoe1U7InkYmUgiUYfZ59CcERAQSOA313lCMIKr5ZDKtfH9/CROMN1DbZexXgWJGpVVp3XweNl+R550re02Y8/JARhheUYB/jArALo+awSa9b7vaWDOQ7XPcR1HDMOxPXnzB84O/TrMcflTTIIr9u+LYyRDm6aK6hVL9MZVB2NmpXyMDeupnEYpujexV8npWufTrRajjIPA6jEFNeEBC5eIDrxgnPLJyskmKNxpZYA/cKnjOniDtwvMvJQHjQAI6R0tuiTA952EoFg==</ds:SignatureValue>
+		<ds:KeyInfo Id="Certificate-679a2f25-7483-11ec-9722-7ea2cb436ff6">
+			<ds:X509Data>
+				<ds:X509Certificate>MIIHhjCCBm6gAwIBAgIQSOSlyjvRFUlfo/hUFNAvqDANBgkqhkiG9w0BAQsFADBLMQswCQYDVQQGEwJFUzERMA8GA1UECgwIRk5NVC1SQ00xDjAMBgNVBAsMBUNlcmVzMRkwFwYDVQQDDBBBQyBGTk1UIFVzdWFyaW9zMB4XDTIwMTEwNTEzMDQyMFoXDTI0MTEwNTEzMDQyMFowgYUxCzAJBgNVBAYTAkVTMRgwFgYDVQQFEw9JRENFUy05OTk5OTk5OVIxEDAOBgNVBCoMB1BSVUVCQVMxGjAYBgNVBAQMEUVJREFTIENFUlRJRklDQURPMS4wLAYDVQQDDCVFSURBUyBDRVJUSUZJQ0FETyBQUlVFQkFTIC0gOTk5OTk5OTlSMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQIDAQABo4IEKTCCBCUwgZIGA1UdEQSBijCBh4Edc29wb3J0ZV90ZWNuaWNvX2NlcmVzQGZubXQuZXOkZjBkMRgwFgYJKwYBBAGsZgEEDAk5OTk5OTk5OVIxGjAYBgkrBgEEAaxmAQMMC0NFUlRJRklDQURPMRQwEgYJKwYBBAGsZgECDAVFSURBUzEWMBQGCSsGAQQBrGYBAQwHUFJVRUJBUzAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIF4DAdBgNVHSUEFjAUBggrBgEFBQcDBAYIKwYBBQUHAwIwHQYDVR0OBBYEFE5aHiQQRwVYJzmmkfG/i5MxmMNdMB8GA1UdIwQYMBaAFLHUT8QjefpEBQnG6znP6DWwuCBkMIGCBggrBgEFBQcBAQR2MHQwPQYIKwYBBQUHMAGGMWh0dHA6Ly9vY3NwdXN1LmNlcnQuZm5tdC5lcy9vY3NwdXN1L09jc3BSZXNwb25kZXIwMwYIKwYBBQUHMAKGJ2h0dHA6Ly93d3cuY2VydC5mbm10LmVzL2NlcnRzL0FDVVNVLmNydDCCARUGA1UdIASCAQwwggEIMIH6BgorBgEEAaxmAwoBMIHrMCkGCCsGAQUFBwIBFh1odHRwOi8vd3d3LmNlcnQuZm5tdC5lcy9kcGNzLzCBvQYIKwYBBQUHAgIwgbAMga1DZXJ0aWZpY2FkbyBjdWFsaWZpY2FkbyBkZSBmaXJtYSBlbGVjdHLDs25pY2EuIFN1amV0byBhIGxhcyBjb25kaWNpb25lcyBkZSB1c28gZXhwdWVzdGFzIGVuIGxhIERQQyBkZSBsYSBGTk1ULVJDTSBjb24gTklGOiBRMjgyNjAwNC1KIChDL0pvcmdlIEp1YW4gMTA2LTI4MDA5LU1hZHJpZC1Fc3Bhw7FhKTAJBgcEAIvsQAEAMIG6BggrBgEFBQcBAwSBrTCBqjAIBgYEAI5GAQEwCwYGBACORgEDAgEPMBMGBgQAjkYBBjAJBgcEAI5GAQYBMHwGBgQAjkYBBTByMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lcy5wZGYTAmVzMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lbi5wZGYTAmVuMIG1BgNVHR8Ega0wgaowgaeggaSggaGGgZ5sZGFwOi8vbGRhcHVzdS5jZXJ0LmZubXQuZXMvY249Q1JMMzc0OCxjbj1BQyUyMEZOTVQlMjBVc3VhcmlvcyxvdT1DRVJFUyxvPUZOTVQtUkNNLGM9RVM/Y2VydGlmaWNhdGVSZXZvY2F0aW9uTGlzdDtiaW5hcnk/YmFzZT9vYmplY3RjbGFzcz1jUkxEaXN0cmlidXRpb25Qb2ludDANBgkqhkiG9w0BAQsFAAOCAQEAH4t5/v/SLsm/dXRDw4QblCmTX+5pgXJ+4G1Lb3KTSPtDJ0UbQiAMUx+iqDDOoMHU5H7po/HZLJXgNwvKLoiLbl5/q6Mqasif87fa6awNkuz/Y6dvXw0UOJh+Ud/Wrk0EyaP9ZtrLVsraUOobNyS6g+lOrCxRrNxGRK2yAeotO6LEo1y3b7CB+Amd2jDq8lY3AtCYlrhuCaTf0AD9IBYYmigHzFD/VH5a8uG95l6J85FQG7tMsG6UQHFM2EmNhpbrYH+ihetz3UhzcC5Fd/P1X7pGBymQgbCyBjCRf/HEVzyoHL72uMp2I4JXX4v8HABZT8xtlDY4LE0am9keJhaNcg==</ds:X509Certificate>
+			</ds:X509Data>
+			<ds:KeyValue>
+				<ds:RSAKeyValue>
+					<ds:Modulus>ujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQ==</ds:Modulus>
+					<ds:Exponent>AQAB</ds:Exponent>
+				</ds:RSAKeyValue>
+			</ds:KeyValue>
+		</ds:KeyInfo>
+		<ds:Object>
+			<xades:QualifyingProperties xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" Id="Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-QualifyingProperties" Target="#Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-Signature">
+				<xades:SignedProperties Id="Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-SignedProperties">
+					<xades:SignedSignatureProperties>
+						<xades:SigningTime>2022-02-01T04:00:00+00:00</xades:SigningTime>
+						<xades:SigningCertificate>
+							<xades:Cert>
+								<xades:CertDigest>
+									<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+									<ds:DigestValue>VmNYwDiCBBXJX/IL1AUYj7uHouM2Jcp3ZkeqmB+FKGTTwXIIZnCWmZVhCSB7uNoV6Xee7nZVkMqeCMQk3tGR0g==</ds:DigestValue>
+								</xades:CertDigest>
+								<xades:IssuerSerial>
+									<ds:X509IssuerName>CN=AC FNMT Usuarios,OU=Ceres,O=FNMT-RCM,C=ES</ds:X509IssuerName>
+									<ds:X509SerialNumber>96891622000445695554354105786026700712</ds:X509SerialNumber>
+								</xades:IssuerSerial>
+							</xades:Cert>
+						</xades:SigningCertificate>
+					</xades:SignedSignatureProperties>
+					<xades:SignedDataObjectProperties>
+						<xades:DataObjectFormat ObjectReference="#Reference-679a2f25-7483-11ec-9722-7ea2cb436ff6">
+							<xades:Description>Fattura PA</xades:Description>
+							<xades:ObjectIdentifier>
+								<xades:Identifier Qualifier="OIDAsURN">urn:oid:1.2.840.10003.5.109.10</xades:Identifier>
+								<xades:Description></xades:Description>
+							</xades:ObjectIdentifier>
+							<xades:MimeType>text/xml</xades:MimeType>
+							<xades:Encoding></xades:Encoding>
+						</xades:DataObjectFormat>
+					</xades:SignedDataObjectProperties>
+				</xades:SignedProperties>
+			</xades:QualifyingProperties>
+		</ds:Object>
+	</ds:Signature>
+</p:FatturaElettronica>


### PR DESCRIPTION
## Context

The community reported two gaps in GOBL→XML conversion for `DettaglioLinee`:

  1. GOBL line item `period.start` and `period.end` fields weren't mapped to FatturaPA's `DataInizioPeriodo` and `DataFinePeriodo`, which is required by Italian law for service invoices.
  2. Lines with Natura `N2.1` (non-territorial operations per art. 7-7septies DPR 633/72) were missing the mandatory `AltriDatiGestionali` block with `INVCONT` value.

## Changes

  - Map `line.Period.Start` and `line.Period.End` to `DataInizioPeriodo` and `DataFinePeriodo` in both directions
  - Add `OtherData` struct for `AltriDatiGestionali` on `DettaglioLinee`
  - GOBL→XML: Add `INVCONT` + legal reference text for `N2.1` lines when the invoice has the `reverse-charge` tag 
  - XML→GOBL: set the `reverse-charge` tag on the invoice when `INVCONT` is present
  - Add test coverage for both directions