### PR TITLE
Fix isPostOfficeBox panic on short street strings

### DIFF
--- a/address_parse.go
+++ b/address_parse.go
@@ -1,10 +1,15 @@
 package fatturapa
 
 import (
+	"strings"
+
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"
 )
+
+// poBoxPrefixes contains common PO Box prefix patterns
+var poBoxPrefixes = []string{"P.O. ", "PO Box ", "P.O.Box", "P.O Box", "PO BOX"}
 
 func goblOrgAddressFromAddress(address *Address) *org.Address {
 	addr := &org.Address{
@@ -39,6 +44,10 @@ func goblOrgAddressFromAddress(address *Address) *org.Address {
 
 // isPostOfficeBox is a helper function to determine if a street address is actually a PO Box
 func isPostOfficeBox(street string) bool {
-	// Simple implementation - could be expanded with regex patterns
-	return len(street) >= 5 && (street[:5] == "P.O. " || street[:7] == "PO Box ")
+	for _, prefix := range poBoxPrefixes {
+		if strings.HasPrefix(street, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/address_parse_internal_test.go
+++ b/address_parse_internal_test.go
@@ -1,0 +1,33 @@
+package fatturapa
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPostOfficeBox(t *testing.T) {
+	tests := []struct {
+		name   string
+		street string
+		want   bool
+	}{
+		{"P.O. prefix", "P.O. 123", true},
+		{"PO Box prefix", "PO Box 123", true},
+		{"P.O.Box prefix", "P.O.Box 123", true},
+		{"P.O Box prefix", "P.O Box 123", true},
+		{"PO BOX prefix", "PO BOX 123", true},
+		{"empty", "", false},
+		{"len 5 non-match", "BOX12", false},
+		{"len 6 non-match", "BOX123", false},
+		{"len 7 non-match", "ROMA 1 ", false},
+		{"PO prefix inside string", "Apt 3, PO Box 12", false},
+		{"lowercase p.o. not matched", "p.o. 123", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPostOfficeBox(tt.street))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`isPostOfficeBox` panics with `slice bounds out of range [:7] with length 6` whenever it's given a street string of length 5 or 6 that doesn't start with `"P.O. "`. The length guard only covers the first prefix check, and when that fails, we end up trying to slice `street[:7]` on a string that's too short.

Any real invoice with a short address line (`"BOX123"`, `"ROMA 1"`) can crash the process. 

## Fix

* Replaced the manual slice comparisons with a `poBoxPrefixes` slice iterated via `strings.HasPrefix`. That removes the panic and extends detection to cover `P.O.Box`, `P.O Box`, and `PO BOX` alongside the existing `P.O. ` and `PO Box `.
 * Added `TestIsPostOfficeBox`, a small table-driven test covering the lengths that used to panic (5, 6, 7), each of the five recognised prefixes, empty input, a non-leading occurrence, and lowercase (which stays unrecognised).