### PR TITLE
Apply foreign-party tax ID defaults to the supplier

### DIFF
--- a/fatturapa.go
+++ b/fatturapa.go
@@ -68,7 +68,10 @@ func Convert(env *gobl.Envelope, opts ...Option) (*Document, error) {
 
 	TransmissionData := newTransmissionData(invoice, env, config.Transmitter)
 
-	header := newHeader(invoice, TransmissionData)
+	header, err := newHeader(invoice, TransmissionData)
+	if err != nil {
+		return nil, err
+	}
 
 	body, err := newBody(invoice)
 	if err != nil {

--- a/header.go
+++ b/header.go
@@ -9,10 +9,14 @@ type Header struct {
 	Customer         *Customer         `xml:"CessionarioCommittente,omitempty"`
 }
 
-func newHeader(inv *bill.Invoice, TransmissionData *TransmissionData) *Header {
+func newHeader(inv *bill.Invoice, TransmissionData *TransmissionData) (*Header, error) {
+	supplier, err := newSupplier(inv.Supplier)
+	if err != nil {
+		return nil, err
+	}
 	return &Header{
 		TransmissionData: TransmissionData,
-		Supplier:         newSupplier(inv.Supplier),
+		Supplier:         supplier,
 		Customer:         newCustomer(inv.Customer),
-	}
+	}, nil
 }

--- a/parties.go
+++ b/parties.go
@@ -1,6 +1,8 @@
 package fatturapa
 
 import (
+	"errors"
+
 	"github.com/invopop/gobl/addons/it/sdi"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"
@@ -90,7 +92,7 @@ type Contact struct {
 	Email     string `xml:"Email,omitempty"`
 }
 
-func newSupplier(s *org.Party) *Supplier {
+func newSupplier(s *org.Party) (*Supplier, error) {
 	ns := &Supplier{
 		Identity: &Identity{
 			Profile: newProfile(s),
@@ -99,11 +101,14 @@ func newSupplier(s *org.Party) *Supplier {
 		Contact:      newContact(s),
 	}
 
-	// Apply the same foreign-party defaulting as the customer so that foreign
-	// suppliers (e.g. on a self-billed invoice received from abroad) get a valid
-	// default ID when they have no VAT number, instead of an empty/invalid one.
 	if s.TaxID != nil {
 		ns.Identity.TaxID = partyTaxID(s.TaxID)
+	}
+	// Unlike the customer's, the supplier's IdFiscaleIVA is mandatory in the
+	// FatturaPA schema, so fail early instead of generating XML that SDI
+	// would reject.
+	if ns.Identity.TaxID == nil {
+		return nil, errors.New("supplier tax ID is required")
 	}
 	if id := org.IdentityForKey(s.Identities, it.IdentityKeyFiscalCode); id != nil {
 		ns.Identity.FiscalCode = id.Code.String()
@@ -119,7 +124,7 @@ func newSupplier(s *org.Party) *Supplier {
 		ns.Address = newAddress(s.Addresses[0])
 	}
 
-	return ns
+	return ns, nil
 }
 
 func newCustomer(c *org.Party) *Customer {
@@ -185,7 +190,8 @@ func newContact(party *org.Party) *Contact {
 // applying the SDI defaults for foreign parties: a non-IT party with no VAT
 // number is treated as a private individual (0000000), and a non-EU party with
 // a VAT number uses the generic non-EU placeholder (OO99999999999). An IT party
-// with no code returns nil so the CodiceFiscale can be used instead.
+// with no code returns nil: an IT customer may identify itself with the
+// CodiceFiscale instead, while an IT supplier must always provide a VAT number.
 func partyTaxID(id *tax.Identity) *TaxID {
 	code := id.Code.String()
 

--- a/parties.go
+++ b/parties.go
@@ -93,14 +93,20 @@ type Contact struct {
 func newSupplier(s *org.Party) *Supplier {
 	ns := &Supplier{
 		Identity: &Identity{
-			TaxID: &TaxID{
-				Country: s.TaxID.Country.String(),
-				Code:    s.TaxID.Code.String(),
-			},
 			Profile: newProfile(s),
 		},
 		Registration: newRegistration(s),
 		Contact:      newContact(s),
+	}
+
+	// Apply the same foreign-party defaulting as the customer so that foreign
+	// suppliers (e.g. on a self-billed invoice received from abroad) get a valid
+	// default ID when they have no VAT number, instead of an empty/invalid one.
+	if s.TaxID != nil {
+		ns.Identity.TaxID = partyTaxID(s.TaxID)
+	}
+	if id := org.IdentityForKey(s.Identities, it.IdentityKeyFiscalCode); id != nil {
+		ns.Identity.FiscalCode = id.Code.String()
 	}
 
 	if v := s.Ext.Get(sdi.ExtKeyFiscalRegime); v != "" {
@@ -131,7 +137,7 @@ func newCustomer(c *org.Party) *Customer {
 	}
 
 	if c.TaxID != nil {
-		da.TaxID = customerTaxID(c.TaxID)
+		da.TaxID = partyTaxID(c.TaxID)
 	}
 	if id := org.IdentityForKey(c.Identities, it.IdentityKeyFiscalCode); id != nil {
 		da.FiscalCode = id.Code.String()
@@ -175,7 +181,12 @@ func newContact(party *org.Party) *Contact {
 	return c
 }
 
-func customerTaxID(id *tax.Identity) *TaxID {
+// partyTaxID builds the FatturaPA tax ID for a party (supplier or customer),
+// applying the SDI defaults for foreign parties: a non-IT party with no VAT
+// number is treated as a private individual (0000000), and a non-EU party with
+// a VAT number uses the generic non-EU placeholder (OO99999999999). An IT party
+// with no code returns nil so the CodiceFiscale can be used instead.
+func partyTaxID(id *tax.Identity) *TaxID {
 	code := id.Code.String()
 
 	if code == "" {

--- a/parties_test.go
+++ b/parties_test.go
@@ -48,6 +48,84 @@ func TestPartiesSupplier(t *testing.T) {
 
 		assert.Equal(t, "RF01", s.Identity.FiscalRegime)
 	})
+
+	t.Run("should keep supplier info for EU company with Tax ID given", func(t *testing.T) {
+		env := test.LoadTestFile("invoice-simple.json", test.PathGOBLFatturaPA)
+		test.ModifyInvoice(env, func(inv *bill.Invoice) {
+			inv.Supplier.TaxID.Code = "81237984062783472"
+			inv.Supplier.TaxID.Country = l10n.AT.Tax()
+		})
+
+		doc, err := test.ConvertFromGOBL(env)
+		require.NoError(t, err)
+
+		s := doc.Header.Supplier
+
+		assert.Equal(t, "AT", s.Identity.TaxID.Country)
+		assert.Equal(t, "81237984062783472", s.Identity.TaxID.Code)
+	})
+
+	t.Run("should default supplier info for EU individual with no Tax ID given", func(t *testing.T) {
+		env := test.LoadTestFile("invoice-simple.json", test.PathGOBLFatturaPA)
+		test.ModifyInvoice(env, func(inv *bill.Invoice) {
+			inv.Supplier.TaxID.Code = ""
+			inv.Supplier.TaxID.Country = l10n.SE.Tax()
+		})
+
+		doc, err := test.ConvertFromGOBL(env)
+		require.NoError(t, err)
+
+		s := doc.Header.Supplier
+
+		assert.Equal(t, "SE", s.Identity.TaxID.Country)
+		assert.Equal(t, "0000000", s.Identity.TaxID.Code)
+	})
+
+	t.Run("should replace supplier ID info for non-EU company with Tax ID given", func(t *testing.T) {
+		env := test.LoadTestFile("invoice-simple.json", test.PathGOBLFatturaPA)
+		test.ModifyInvoice(env, func(inv *bill.Invoice) {
+			inv.Supplier.TaxID.Code = "09823876432"
+			inv.Supplier.TaxID.Country = l10n.GB.Tax()
+		})
+
+		doc, err := test.ConvertFromGOBL(env)
+		require.NoError(t, err)
+
+		s := doc.Header.Supplier
+
+		assert.Equal(t, "GB", s.Identity.TaxID.Country)
+		assert.Equal(t, "OO99999999999", s.Identity.TaxID.Code)
+	})
+
+	t.Run("should default supplier info for non-EU individual with no Tax ID given", func(t *testing.T) {
+		env := test.LoadTestFile("invoice-simple.json", test.PathGOBLFatturaPA)
+		test.ModifyInvoice(env, func(inv *bill.Invoice) {
+			inv.Supplier.TaxID.Code = ""
+			inv.Supplier.TaxID.Country = l10n.JP.Tax()
+		})
+
+		doc, err := test.ConvertFromGOBL(env)
+		require.NoError(t, err)
+
+		s := doc.Header.Supplier
+
+		assert.Equal(t, "JP", s.Identity.TaxID.Country)
+		assert.Equal(t, "0000000", s.Identity.TaxID.Code)
+	})
+
+	t.Run("should not fail if supplier has no Tax ID", func(t *testing.T) {
+		env := test.LoadTestFile("invoice-simple.json", test.PathGOBLFatturaPA)
+		test.ModifyInvoice(env, func(inv *bill.Invoice) {
+			inv.Supplier.TaxID = nil
+		})
+
+		doc, err := test.ConvertFromGOBL(env)
+		require.NoError(t, err)
+
+		s := doc.Header.Supplier
+
+		assert.Nil(t, s.Identity.TaxID)
+	})
 }
 
 func TestPartiesCustomer(t *testing.T) {

--- a/parties_test.go
+++ b/parties_test.go
@@ -113,18 +113,24 @@ func TestPartiesSupplier(t *testing.T) {
 		assert.Equal(t, "0000000", s.Identity.TaxID.Code)
 	})
 
-	t.Run("should not fail if supplier has no Tax ID", func(t *testing.T) {
+	t.Run("should return an error if supplier has no Tax ID", func(t *testing.T) {
 		env := test.LoadTestFile("invoice-simple.json", test.PathGOBLFatturaPA)
 		test.ModifyInvoice(env, func(inv *bill.Invoice) {
 			inv.Supplier.TaxID = nil
 		})
 
-		doc, err := test.ConvertFromGOBL(env)
-		require.NoError(t, err)
+		_, err := test.ConvertFromGOBL(env)
+		require.ErrorContains(t, err, "supplier tax ID is required")
+	})
 
-		s := doc.Header.Supplier
+	t.Run("should return an error for IT supplier with no Tax ID code", func(t *testing.T) {
+		env := test.LoadTestFile("invoice-simple.json", test.PathGOBLFatturaPA)
+		test.ModifyInvoice(env, func(inv *bill.Invoice) {
+			inv.Supplier.TaxID.Code = ""
+		})
 
-		assert.Nil(t, s.Identity.TaxID)
+		_, err := test.ConvertFromGOBL(env)
+		require.ErrorContains(t, err, "supplier tax ID is required")
 	})
 }
 


### PR DESCRIPTION
## Problem

When converting a GOBL invoice to FatturaPA, the foreign-party defaulting that SDI requires was applied only to the **customer**. The **supplier** was built with its `IdFiscaleIVA` taken verbatim, and `newSupplier` dereferenced `s.TaxID` unconditionally. As a result, a foreign supplier (e.g. on a self-billed invoice received from abroad) with no VAT number produced an empty/invalid `IdFiscaleIVA`, and a `nil` `TaxID` caused a panic.

## Change

- Generalise `customerTaxID` into a shared `partyTaxID` helper (no behaviour change for the customer path).
- Build the supplier's `IdFiscaleIVA` via `partyTaxID`, guarding against a `nil` `TaxID`, and mirror the customer's `CodiceFiscale` handling.

This means foreign suppliers now follow the same rules as customers:
- non-IT party with no VAT number → individual default `0000000`
- non-EU party with a VAT number → `OO99999999999`
- IT party with no code → falls back to `CodiceFiscale`