### PR TITLE
Stop double-counting the FatturaPA Arrotondamento on import

### DIFF
--- a/body_parse.go
+++ b/body_parse.go
@@ -183,17 +183,6 @@ func goblBillInvoiceAddGeneralDocumentData(inv *bill.Invoice, doc *GeneralDocume
 		inv.Totals.Payable = payable
 	}
 
-	// Add totals rounding
-	if doc.Rounding != "" {
-		rounding, err := parseAmount(doc.Rounding)
-		if err != nil {
-			return fmt.Errorf("adding rounding: %w", err)
-		}
-		if inv.Totals == nil {
-			inv.Totals = new(bill.Totals)
-		}
-		inv.Totals.Rounding = &rounding
-	}
 	// Add stamp duty
 	goblBillInvoiceAddStampDuty(inv, doc.StampDuty)
 

--- a/body_parse_test.go
+++ b/body_parse_test.go
@@ -164,6 +164,7 @@ func TestBodyInConversion(t *testing.T) {
 		require.NotNil(t, inv.Totals)
 		require.NotNil(t, inv.Totals.Rounding)
 		require.Equal(t, inv.Totals.Rounding.String(), "0.01")
+		require.Equal(t, "1388.41", inv.Totals.Payable.String())
 
 	})
 
@@ -182,6 +183,7 @@ func TestBodyInConversion(t *testing.T) {
 		require.NotNil(t, inv.Totals)
 		require.NotNil(t, inv.Totals.Rounding)
 		require.Equal(t, inv.Totals.Rounding.String(), "0.01")
+		require.Equal(t, "1388.41", inv.Totals.Payable.String())
 
 	})
 }

--- a/roundtrip_rounding_test.go
+++ b/roundtrip_rounding_test.go
@@ -1,0 +1,75 @@
+package fatturapa_test
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/invopop/gobl"
+	"github.com/invopop/gobl.fatturapa/test"
+	"github.com/invopop/gobl/bill"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRoundTripPreservesPayable checks that an inclusive-priced invoice's
+// payable survives a GOBL -> FatturaPA -> GOBL round-trip.
+func TestRoundTripPreservesPayable(t *testing.T) {
+	// Inclusive prices whose net conversion doesn't divide evenly, so the
+	// FatturaPA carries an Arrotondamento.
+	const goblJSON = `{
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "IT",
+		"$addons": ["it-sdi-v1"],
+		"uuid": "019ed4dc-f12a-790b-8fa1-2d13de01f9a6",
+		"type": "standard",
+		"code": "0001",
+		"issue_date": "2026-06-17",
+		"currency": "EUR",
+		"tax": {
+			"prices_include": "VAT",
+			"rounding": "currency",
+			"ext": {"it-sdi-document-type": "TD01", "it-sdi-format": "FPR12"}
+		},
+		"supplier": {
+			"name": "Azienda Pippo Fatture S.r.l.",
+			"tax_id": {"country": "IT", "code": "31122336964"},
+			"addresses": [{"num": "42", "street": "Via Milano", "locality": "Milan", "region": "MI", "code": "20121", "country": "IT"}],
+			"ext": {"it-sdi-fiscal-regime": "RF01"}
+		},
+		"customer": {
+			"name": "Test Business S.r.l.",
+			"tax_id": {"country": "IT", "code": "12345670017"},
+			"addresses": [{"num": "1", "street": "Via Nazionale", "locality": "Rome", "code": "00184", "country": "IT"}]
+		},
+		"lines": [
+			{
+				"quantity": "3.00",
+				"item": {"name": "Coffee", "price": "2.50"},
+				"discounts": [{"reason": "Special Discount", "amount": "0.15"}],
+				"charges": [{"reason": "Special Surcharge", "amount": "0.08"}],
+				"taxes": [{"cat": "VAT", "key": "standard", "percent": "22.00%"}]
+			}
+		]
+	}`
+
+	out, err := gobl.Parse([]byte(goblJSON))
+	require.NoError(t, err)
+	env := gobl.NewEnvelope()
+	require.NoError(t, env.Insert(out))
+
+	sent, ok := env.Extract().(*bill.Invoice)
+	require.True(t, ok)
+	require.Equal(t, "7.43", sent.Totals.Payable.String())
+
+	doc, err := test.ConvertFromGOBL(env, test.LoadOptions()...)
+	require.NoError(t, err)
+	xmlData, err := xml.Marshal(doc)
+	require.NoError(t, err)
+
+	back, err := test.ConvertToGOBL(xmlData)
+	require.NoError(t, err)
+	imported, ok := back.Extract().(*bill.Invoice)
+	require.True(t, ok)
+
+	assert.Equal(t, "7.43", imported.Totals.Payable.String())
+}


### PR DESCRIPTION
## Context

Sending a FatturaPA invoice and importing the same XML back changed the payable by a cent (7,43 → 7,44). On import we both read `<Arrotondamento>` into `Totals.Rounding` and ran `adjustTotals`, which already reconciles the recalculated totals to `ImportoTotaleDocumento`. The two double-count the rounding.

## Changes

- `body_parse.go`: stop reading `<Arrotondamento>`; `adjustTotals` owns rounding.
- `body_parse_test.go`: the two rounding tests now assert the payable, not just that a rounding exists.
- `roundtrip_rounding_test.go`: round-trip test asserting the payable survives.
