### PR TITLE
Extract the it-sdi addon from GOBL

### DIFF
--- a/addon/address.go
+++ b/addon/address.go
@@ -1,0 +1,27 @@
+package sdi
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/org"
+)
+
+func normalizeAddress(addr *org.Address) {
+	if addr == nil || addr.Country != l10n.IT.ISO() {
+		return
+	}
+
+	// ensure the Code is always 5 digits with 0 padding
+	if len(addr.Code) > 0 && len(addr.Code) < 5 {
+		// convert to number
+		code, err := strconv.Atoi(addr.Code.String())
+		if err != nil {
+			// not a number, ignore
+			return
+		}
+		addr.Code = cbc.Code(fmt.Sprintf("%05d", code))
+	}
+}

--- a/addon/address_test.go
+++ b/addon/address_test.go
@@ -1,0 +1,63 @@
+package sdi_test
+
+import (
+	"testing"
+
+	sdi "github.com/invopop/gobl.fatturapa/addon"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeTest(t *testing.T) {
+	t.Run("nil address", func(t *testing.T) {
+		var addr *org.Address
+		assert.NotPanics(t, func() {
+			norm.Normalize(addr, tax.AddonContext(sdi.V1))
+		})
+	})
+	t.Run("normalize short code", func(t *testing.T) {
+		addr := &org.Address{
+			Country: l10n.IT.ISO(),
+			Code:    cbc.Code("123"),
+		}
+		norm.Normalize(addr, tax.AddonContext(sdi.V1))
+		assert.Equal(t, cbc.Code("00123"), addr.Code)
+	})
+	t.Run("missing code", func(t *testing.T) {
+		addr := &org.Address{
+			Country: l10n.IT.ISO(),
+			Code:    cbc.Code(""),
+		}
+		norm.Normalize(addr, tax.AddonContext(sdi.V1))
+		assert.Equal(t, cbc.Code(""), addr.Code)
+	})
+	t.Run("ignore invalid code", func(t *testing.T) {
+		addr := &org.Address{
+			Country: l10n.IT.ISO(),
+			Code:    cbc.Code("1A3"),
+		}
+		norm.Normalize(addr, tax.AddonContext(sdi.V1))
+		assert.Equal(t, cbc.Code("1A3"), addr.Code)
+	})
+	t.Run("ignore invalid code", func(t *testing.T) {
+		addr := &org.Address{
+			Country: l10n.IT.ISO(),
+			Code:    cbc.Code("1A3"),
+		}
+		norm.Normalize(addr, tax.AddonContext(sdi.V1))
+		assert.Equal(t, cbc.Code("1A3"), addr.Code)
+	})
+	t.Run("ignore other countries", func(t *testing.T) {
+		addr := &org.Address{
+			Country: l10n.ES.ISO(),
+			Code:    cbc.Code("1A3"),
+		}
+		norm.Normalize(addr, tax.AddonContext(sdi.V1))
+		assert.Equal(t, cbc.Code("1A3"), addr.Code)
+	})
+
+}

--- a/addon/bill.go
+++ b/addon/bill.go
@@ -1,0 +1,313 @@
+package sdi
+
+import (
+	"fmt"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/it"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+func normalizeInvoice(inv *bill.Invoice) {
+	normalizeSupplier(inv.Supplier)
+}
+
+func normalizeSupplier(party *org.Party) {
+	if party == nil {
+		return
+	}
+	if party.Ext.Get(ExtKeyFiscalRegime) == "" {
+		// Ordinary regime is default
+		party.Ext = party.Ext.Set(ExtKeyFiscalRegime, "RF01")
+	}
+
+	// Normalize Italian supplier telephone numbers by stripping '+39' prefix
+	if isItalianParty(party) && len(party.Telephones) > 0 {
+		for _, tel := range party.Telephones {
+			if tel != nil && len(tel.Number) >= 3 && tel.Number[:3] == "+39" {
+				tel.Number = tel.Number[3:]
+			}
+		}
+	}
+}
+
+func billInvoiceRules() *rules.Set {
+	return rules.For(new(bill.Invoice),
+		rules.Assert("22", "invoice must be in EUR or provide exchange rate for conversion", currency.CanConvertTo(currency.EUR)),
+		rules.Field("tax",
+			rules.Assert("01", "tax is required", is.Present),
+			rules.Field("ext",
+				rules.Assert("02",
+					fmt.Sprintf("tax requires '%s' and '%s' extensions", ExtKeyDocumentType, ExtKeyFormat),
+					tax.ExtensionsRequire(
+						ExtKeyFormat,
+						ExtKeyDocumentType,
+					),
+				),
+			),
+		),
+		rules.Field("supplier",
+			rules.Field("name",
+				rules.Assert("03", "supplier name must use Latin-1 characters",
+					is.FuncError("latin1", validateLatin1String),
+				),
+			),
+			rules.Field("addresses",
+				rules.Assert("04", "supplier addresses are required", is.Present),
+			),
+			rules.Field("ext",
+				rules.Assert("05",
+					fmt.Sprintf("supplier requires '%s' extension", ExtKeyFiscalRegime),
+					tax.ExtensionsRequire(ExtKeyFiscalRegime),
+				),
+			),
+			rules.Field("registration",
+				rules.Field("entry",
+					rules.Assert("06", "supplier registration entry is required when registration is present",
+						is.Present,
+					),
+				),
+				rules.Field("office",
+					rules.Assert("07", "supplier registration office is required when registration is present",
+						is.Present,
+					),
+				),
+			),
+		),
+		rules.When(is.Func("supplier is Italian", invoiceSupplierIsItalian),
+			rules.Field("supplier",
+				rules.Field("telephones",
+					rules.Each(
+						rules.Field("num",
+							rules.Assert("08", "Italian telephone number length must be between 5 and 12",
+								is.Length(5, 12),
+							),
+						),
+					),
+				),
+			),
+		),
+		rules.Field("customer",
+			rules.Assert("09", "customer is required", is.Present),
+			rules.Field("name",
+				rules.Assert("10", "customer name must use Latin-1 characters",
+					is.FuncError("latin1", validateLatin1String),
+				),
+			),
+			rules.Field("tax_id",
+				rules.Assert("11", "customer tax ID is required", is.Present),
+			),
+			rules.Field("addresses",
+				rules.Assert("12", "customer addresses are required", is.Present),
+			),
+		),
+		// Customer name required when tax_id code is present or people is nil
+		rules.Assert("13", "customer name is required",
+			is.Func("customer name check", invoiceCustomerHasNameOrPeople),
+		),
+		// Customer people required when name is empty
+		rules.Assert("14", "customer people are required when name is empty",
+			is.Func("customer people check", invoiceCustomerHasPeopleOrName),
+		),
+		// Customer tax_id code required for Italian parties without fiscal code
+		rules.When(is.Func("Italian customer without fiscal code", invoiceCustomerIsItalianWithoutFiscalCode),
+			rules.Field("customer",
+				rules.Field("tax_id",
+					rules.Field("code",
+						rules.Assert("15", "customer tax ID code is required for Italian parties without fiscal code",
+							is.Present,
+						),
+					),
+				),
+			),
+		),
+		// Customer identity required for Italian parties without tax ID code
+		rules.When(is.Func("Italian customer without tax ID code", invoiceCustomerIsItalianWithoutTaxIDCode),
+			rules.Field("customer",
+				rules.Field("identities",
+					rules.Assert("16",
+						fmt.Sprintf("customer requires identity with key '%s'", it.IdentityKeyFiscalCode),
+						is.Func("has fiscal code", invoiceCustomerHasFiscalCodeIdentity),
+					),
+				),
+			),
+		),
+		rules.Field("lines",
+			rules.Each(
+				rules.Assert("17", "line must have VAT tax category",
+					bill.RequireLineTaxCategory(tax.CategoryVAT),
+				),
+				rules.Field("item",
+					rules.Field("name",
+						rules.Assert("18", "item name must use Latin-1 characters",
+							is.FuncError("latin1", validateLatin1String),
+						),
+					),
+				),
+			),
+		),
+		// Ordering despatch validation
+		rules.When(is.Func("has deferred tag", invoiceHasDeferredTag),
+			rules.Field("ordering",
+				rules.Field("despatch",
+					rules.Each(
+						rules.Field("issue_date",
+							rules.Assert("19", "despatch issue date is required", is.Present),
+						),
+					),
+				),
+			),
+		),
+		rules.When(is.Func("no deferred tag", invoiceDoesNotHaveDeferredTag),
+			rules.Field("ordering",
+				rules.Field("despatch",
+					rules.Assert("20", "despatch can only be set when invoice has deferred tag", is.Empty),
+				),
+			),
+		),
+		// Payment: instructions required when terms have due dates
+		rules.Assert("21", "payment instructions are required when terms with due dates are present",
+			is.Func("payment instructions check", invoicePaymentInstructionsPresent),
+		),
+	)
+}
+
+func billChargeRules() *rules.Set {
+	return rules.For(new(bill.Charge),
+		rules.When(is.Func("is fund contribution", chargeIsFundContribution),
+			rules.Field("percent",
+				rules.Assert("01", "fund contribution charge requires a percentage", is.Present),
+			),
+			rules.Field("ext",
+				rules.Assert("02",
+					fmt.Sprintf("fund contribution charge requires '%s' extension", ExtKeyFundType),
+					tax.ExtensionsRequire(ExtKeyFundType),
+				),
+			),
+			rules.Field("taxes",
+				rules.Assert("03", "fund contribution charge must have VAT tax category",
+					tax.SetHasCategory(tax.CategoryVAT),
+				),
+			),
+		),
+	)
+}
+
+// --- Helper functions for rules ---
+
+func invoiceSupplierIsItalian(val any) bool {
+	inv, ok := val.(*bill.Invoice)
+	if !ok || inv == nil {
+		return false
+	}
+	return isItalianParty(inv.Supplier)
+}
+
+func invoiceCustomerHasNameOrPeople(val any) bool {
+	inv, ok := val.(*bill.Invoice)
+	if !ok || inv == nil || inv.Customer == nil {
+		return true
+	}
+	c := inv.Customer
+	// Name required when tax_id code is present or people is nil
+	if (c.TaxID != nil && c.TaxID.Code != cbc.CodeEmpty) || c.People == nil {
+		return c.Name != ""
+	}
+	return true
+}
+
+func invoiceCustomerHasPeopleOrName(val any) bool {
+	inv, ok := val.(*bill.Invoice)
+	if !ok || inv == nil || inv.Customer == nil {
+		return true
+	}
+	c := inv.Customer
+	if c.Name == "" {
+		return len(c.People) > 0
+	}
+	return true
+}
+
+func invoiceCustomerIsItalianWithoutFiscalCode(val any) bool {
+	inv, ok := val.(*bill.Invoice)
+	if !ok || inv == nil || inv.Customer == nil {
+		return false
+	}
+	return isItalianParty(inv.Customer) && !hasFiscalCode(inv.Customer)
+}
+
+func invoiceCustomerIsItalianWithoutTaxIDCode(val any) bool {
+	inv, ok := val.(*bill.Invoice)
+	if !ok || inv == nil || inv.Customer == nil {
+		return false
+	}
+	return isItalianParty(inv.Customer) && !hasTaxIDCode(inv.Customer)
+}
+
+func invoiceCustomerHasFiscalCodeIdentity(val any) bool {
+	ids, ok := val.([]*org.Identity)
+	if !ok {
+		return false
+	}
+	return org.IdentityForKey(ids, it.IdentityKeyFiscalCode) != nil
+}
+
+func invoiceHasDeferredTag(val any) bool {
+	inv, ok := val.(*bill.Invoice)
+	if !ok || inv == nil {
+		return false
+	}
+	return inv.HasTags(TagDeferred)
+}
+
+func invoiceDoesNotHaveDeferredTag(val any) bool {
+	inv, ok := val.(*bill.Invoice)
+	if !ok || inv == nil {
+		return true
+	}
+	return !inv.HasTags(TagDeferred)
+}
+
+func invoicePaymentInstructionsPresent(val any) bool {
+	inv, ok := val.(*bill.Invoice)
+	if !ok || inv == nil || inv.Payment == nil {
+		return true
+	}
+	p := inv.Payment
+	if p.Terms != nil && len(p.Terms.DueDates) > 0 {
+		return p.Instructions != nil
+	}
+	return true
+}
+
+func chargeIsFundContribution(val any) bool {
+	c, ok := val.(*bill.Charge)
+	if !ok || c == nil {
+		return false
+	}
+	return c.Key.Has(KeyFundContribution)
+}
+
+func hasTaxIDCode(party *org.Party) bool {
+	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
+}
+
+func hasFiscalCode(party *org.Party) bool {
+	if party == nil {
+		return false
+	}
+	return org.IdentityForKey(party.Identities, it.IdentityKeyFiscalCode) != nil
+
+}
+
+func isItalianParty(party *org.Party) bool {
+	if party == nil || party.TaxID == nil {
+		return false
+	}
+	return party.TaxID.Country.In("IT")
+}

--- a/addon/bill_test.go
+++ b/addon/bill_test.go
@@ -1,0 +1,914 @@
+package sdi_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdi "github.com/invopop/gobl.fatturapa/addon"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/pay"
+	"github.com/invopop/gobl/regimes/it"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testInvoiceStandard(t *testing.T) *bill.Invoice {
+	t.Helper()
+	i := &bill.Invoice{
+		Regime:   tax.WithRegime("IT"),
+		Addons:   tax.WithAddons(sdi.V1),
+		Code:     "123TEST",
+		Currency: "EUR",
+		Tax: &bill.Tax{
+			PricesInclude: tax.CategoryVAT,
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				sdi.ExtKeyDocumentType: "TD01",
+				sdi.ExtKeyFormat:       "FPA12",
+			}),
+		},
+		Type: bill.InvoiceTypeStandard,
+		Supplier: &org.Party{
+			Name: "Test Supplier",
+			TaxID: &tax.Identity{
+				Country: "IT",
+				Code:    "12345678903",
+			},
+			Addresses: []*org.Address{
+				{
+					Street:   "Via di Test",
+					Code:     "12345",
+					Locality: "Rome",
+					Country:  "IT",
+					Number:   "3",
+				},
+			},
+		},
+		Customer: &org.Party{
+			Name: "Test Customer",
+			TaxID: &tax.Identity{
+				Country: "IT",
+				Code:    "13029381004",
+			},
+			Addresses: []*org.Address{
+				{
+					Street:   "Piazza di Test",
+					Code:     "38342",
+					Locality: "Venezia",
+					Country:  "IT",
+					Number:   "1",
+				},
+			},
+		},
+		IssueDate: cal.MakeDate(2022, 6, 13),
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(10, 0),
+				Item: &org.Item{
+					Name:  "Test Item",
+					Price: num.NewAmount(10000, 2),
+				},
+				Taxes: tax.Set{
+					{
+						Category: "VAT",
+						Rate:     "general",
+					},
+				},
+				Discounts: []*bill.LineDiscount{
+					{
+						Reason:  "Testing",
+						Percent: num.NewPercentage(10, 2),
+					},
+				},
+			},
+		},
+	}
+	return i
+}
+
+func withSDIContext() rules.WithContext {
+	return func(rc *rules.Context) {
+		rc.Set(rules.ContextKey(sdi.V1), tax.AddonForKey(sdi.V1))
+	}
+}
+
+func TestInvoiceValidation(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+
+		inv := testInvoiceStandard(t)
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, rules.Validate(inv))
+	})
+	t.Run("missing tax extensions", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		require.NoError(t, inv.Calculate())
+		inv.Tax.Ext = tax.Extensions{}
+		err := rules.Validate(inv)
+		require.ErrorContains(t, err, "tax requires 'it-sdi-document-type' and 'it-sdi-format' extensions")
+	})
+
+	t.Run("non-EUR currency without exchange rates", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-IT-SDI-BILL-INVOICE-22] invoice must be in EUR or provide exchange rate for conversion")
+	})
+
+	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "EUR",
+				Amount: num.MakeAmount(875967, 6),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
+	})
+}
+
+func TestInvoiceNormalization(t *testing.T) {
+
+	t.Run("supplier fiscal regime", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		assert.Equal(t, "RF01", inv.Supplier.Ext.Get(sdi.ExtKeyFiscalRegime).String())
+	})
+
+	t.Run("strip +39 from italian supplier telephone", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Telephones = []*org.Telephone{{Number: "+39333123456"}}
+		norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		require.Len(t, inv.Supplier.Telephones, 1)
+		assert.Equal(t, "333123456", inv.Supplier.Telephones[0].Number)
+	})
+
+	t.Run("non-italian supplier telephone not normalized", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.TaxID.Country = "FR"
+		inv.Supplier.Telephones = []*org.Telephone{{Number: "+39333123456"}}
+		norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		require.Len(t, inv.Supplier.Telephones, 1)
+		assert.Equal(t, "+39333123456", inv.Supplier.Telephones[0].Number)
+	})
+
+	t.Run("no telephones nothing happens", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Telephones = nil
+		norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		assert.Nil(t, inv.Supplier.Telephones)
+	})
+
+	t.Run("italian supplier telephone without +39 prefix not normalized", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Telephones = []*org.Telephone{{Number: "333123456"}}
+		norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		require.Len(t, inv.Supplier.Telephones, 1)
+		assert.Equal(t, "333123456", inv.Supplier.Telephones[0].Number)
+	})
+}
+
+func TestSupplierValidation(t *testing.T) {
+	t.Run("with supplier registration details", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Registration = &org.Registration{
+			Entry:  "123456",
+			Office: "Rome",
+		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("with supplier missing registration details", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Registration = &org.Registration{
+			Entry: "123456",
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "supplier registration office is required")
+	})
+
+	t.Run("with invalid tax ID code", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.TaxID = &tax.Identity{
+			Country: "IT",
+			Code:    "RSSGNN60R30H501U",
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid Italian VAT identity code")
+	})
+
+	t.Run("missing supplier", func(t *testing.T) {
+		// Verify normalizer doesn't panic with nil supplier
+		inv := testInvoiceStandard(t)
+		inv.Supplier = nil
+		assert.NotPanics(t, func() {
+			norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		})
+	})
+
+	t.Run("valid Latin-1 supplier name", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		// Test with valid Latin-1 characters including accented characters
+		inv.Supplier.Name = "Società di Test SRL àáâãäåæçèéêë"
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("invalid supplier name with non-Latin-1 characters", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		// Test with emoji (outside Latin-1 range)
+		inv.Supplier.Name = "Test Supplier 😊"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "supplier name must use Latin-1 characters")
+	})
+
+	t.Run("invalid supplier name with Greek characters", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		// Test with Greek characters (outside Latin-1 range)
+		inv.Supplier.Name = "Test Supplier αβγδε"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "supplier name must use Latin-1 characters")
+	})
+}
+
+func TestCustomerValidation(t *testing.T) {
+	id := &org.Identity{
+		Key:  it.IdentityKeyFiscalCode,
+		Code: "RSSGNN60R30H501U",
+	}
+	t.Run("valid", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.TaxID = &tax.Identity{
+			Country: "IT",
+			Code:    "",
+		}
+		inv.Customer.Identities = append(inv.Customer.Identities, id)
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("missing tax_id", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.TaxID = nil
+		inv.Customer.Identities = append(inv.Customer.Identities, id)
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "customer tax ID is required")
+	})
+
+	t.Run("missing tax id code and identity", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.TaxID = &tax.Identity{
+			Country: "IT",
+			Code:    "",
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		// ensure contains both errors
+		assert.ErrorContains(t, err, fmt.Sprintf("customer requires identity with key '%s'", it.IdentityKeyFiscalCode))
+		assert.ErrorContains(t, err, "customer tax ID code is required")
+	})
+
+	t.Run("missing address", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.Addresses = nil
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "customer addresses are required")
+	})
+
+	t.Run("missing customer", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer = nil
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "customer is required")
+	})
+
+	t.Run("valid Latin-1 customer name", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		// Test with valid Latin-1 characters including special symbols
+		inv.Customer.Name = "Cliente & Cia. S.p.A. ñöüß"
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("invalid customer name with Chinese characters", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		// Test with Chinese characters (outside Latin-1 range)
+		inv.Customer.Name = "测试客户"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "customer name must use Latin-1 characters")
+	})
+
+	t.Run("missing customer name", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.Name = ""
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "customer name is required")
+	})
+
+	t.Run("missing customer people with identity", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.TaxID.Code = ""
+		inv.Customer.Name = ""
+		inv.Customer.Identities = append(inv.Customer.Identities, id)
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "customer name is required")
+		assert.ErrorContains(t, err, "customer people are required when name is empty")
+	})
+
+}
+
+func TestSupplierTelephoneValidation(t *testing.T) {
+	t.Run("valid italian supplier telephone", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Telephones = []*org.Telephone{{Number: "A1B2C3"}}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("invalid italian supplier telephone too short", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Telephones = []*org.Telephone{{Number: "1234"}}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "Italian telephone number length must be between 5 and 12")
+	})
+
+	t.Run("valid italian supplier telephone with symbols", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Telephones = []*org.Telephone{{Number: "+39333123456"}}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("valid italian number, because normalized", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Telephones = []*org.Telephone{{Number: "+393331234567"}}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+		assert.Equal(t, "3331234567", inv.Supplier.Telephones[0].Number)
+	})
+
+	t.Run("invalid italian supplier telephone too long", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Telephones = []*org.Telephone{{Number: "1233312345678"}}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "Italian telephone number length must be between 5 and 12")
+	})
+
+	t.Run("missing italian supplier telephones", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		// No telephones set
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("non-italian supplier telephone not validated", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.TaxID.Country = "FR"
+		inv.Supplier.Telephones = []*org.Telephone{{Number: "1234"}} // Too short, but should be ignored
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("italian supplier telephone too short without prefix", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Telephones = []*org.Telephone{{Number: "1234"}}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "Italian telephone number length must be between 5 and 12")
+	})
+
+	t.Run("no telephones nothing validated", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Telephones = nil
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+}
+
+func TestTaxValidation(t *testing.T) {
+	t.Run("missing tax", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		require.NoError(t, inv.Calculate())
+		inv.Tax = nil
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "tax is required")
+	})
+}
+
+func TestChargesValidation(t *testing.T) {
+	t.Run("charge with no key", func(t *testing.T) {
+		c := &bill.Charge{
+			Percent: num.NewPercentage(10, 2),
+		}
+		err := rules.Validate(c, withSDIContext())
+		assert.NoError(t, err)
+	})
+
+	t.Run("fund contribution charge missing extension", func(t *testing.T) {
+		c := &bill.Charge{
+			Key:     sdi.KeyFundContribution,
+			Percent: num.NewPercentage(10, 2),
+			Taxes: tax.Set{
+				{
+					Category: tax.CategoryVAT,
+					Rate:     "standard",
+				},
+			},
+		}
+		err := rules.Validate(c, withSDIContext())
+		assert.ErrorContains(t, err, fmt.Sprintf("fund contribution charge requires '%s' extension", sdi.ExtKeyFundType))
+	})
+
+	t.Run("fund contribution charge with valid extension", func(t *testing.T) {
+		c := &bill.Charge{
+			Key:     sdi.KeyFundContribution,
+			Percent: num.NewPercentage(10, 2),
+			Taxes: tax.Set{
+				{
+					Category: tax.CategoryVAT,
+					Rate:     "standard",
+					Percent:  num.NewPercentage(22, 2),
+				},
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				sdi.ExtKeyFundType: "TC04",
+			}),
+		}
+		err := rules.Validate(c, withSDIContext())
+		assert.NoError(t, err)
+	})
+
+	t.Run("nil charge", func(t *testing.T) {
+		var c *bill.Charge
+		err := rules.Validate(c, withSDIContext())
+		assert.NoError(t, err)
+	})
+
+	t.Run("fund contribution charge with missing taxes", func(t *testing.T) {
+		c := &bill.Charge{
+			Key:     sdi.KeyFundContribution,
+			Percent: num.NewPercentage(10, 2),
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				sdi.ExtKeyFundType: "TC04",
+			}),
+		}
+		err := rules.Validate(c, withSDIContext())
+		assert.ErrorContains(t, err, "fund contribution charge must have VAT tax category")
+	})
+
+	t.Run("fund contribution charge with missing percentage", func(t *testing.T) {
+		c := &bill.Charge{
+			Key:    sdi.KeyFundContribution,
+			Amount: num.MakeAmount(100, 2),
+			Taxes: tax.Set{
+				{
+					Category: tax.CategoryVAT,
+					Rate:     "standard",
+				},
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				sdi.ExtKeyFundType: "TC04",
+			}),
+		}
+		err := rules.Validate(c, withSDIContext())
+		assert.ErrorContains(t, err, "fund contribution charge requires a percentage")
+	})
+}
+
+func TestPaymentValidation(t *testing.T) {
+
+	t.Run("payment advances", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment = &bill.PaymentDetails{
+			Advances: []*pay.Record{
+				{
+					Description: "Paid up front",
+					Percent:     num.NewPercentage(100, 3),
+					Key:         "card",
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("payment terms missing instructions", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment = &bill.PaymentDetails{
+			Terms: &pay.Terms{
+				DueDates: []*pay.DueDate{
+					{
+						Date:    cal.NewDate(2022, 6, 13),
+						Percent: num.NewPercentage(100, 3),
+					},
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "payment instructions are required when terms with due dates are present")
+	})
+
+	t.Run("payment terms with no due dates", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment = &bill.PaymentDetails{
+			Terms: &pay.Terms{
+				Key: "instant",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
+	})
+
+	t.Run("payment terms with instructions", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment = &bill.PaymentDetails{
+			Terms: &pay.Terms{
+				DueDates: []*pay.DueDate{
+					{
+						Date:    cal.NewDate(2022, 6, 13),
+						Percent: num.NewPercentage(100, 3),
+					},
+				},
+			},
+			Instructions: &pay.Instructions{
+				Key: "card",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+		assert.Equal(t, "MP08", inv.Payment.Instructions.Ext.Get(sdi.ExtKeyPaymentMeans).String())
+	})
+
+}
+
+func TestAddressesValidation(t *testing.T) {
+	t.Run("missing addresses", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Addresses = nil
+		inv.Customer.Addresses = nil
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "supplier addresses are required")
+		assert.Contains(t, err.Error(), "customer addresses are required")
+	})
+
+	t.Run("missing country", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Addresses[0].Country = ""
+		inv.Customer.Addresses[0].Country = ""
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "country is required")
+	})
+
+	t.Run("invalid code", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.Addresses[0].Code = "123456"
+		inv.Supplier.Addresses[0].Code = "123456"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "Italian address code must be 5 digits")
+	})
+
+	t.Run("codes in foreign country", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.Addresses[0].Country = "AT"
+		inv.Supplier.Addresses[0].Country = "AT"
+		inv.Customer.Addresses[0].Code = "1234"
+		inv.Supplier.Addresses[0].Code = "1234"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid Latin-1 address fields", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		// Test with valid Latin-1 characters in address
+		inv.Supplier.Addresses[0].Street = "Via dell'Università ñ°"
+		inv.Supplier.Addresses[0].Locality = "Città di Castello àèìòù"
+		inv.Customer.Addresses[0].Street = "Rue de la Paix é"
+		inv.Customer.Addresses[0].Locality = "Saint-Étienne ç"
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("invalid supplier address street with emoji", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Addresses[0].Street = "Via Test 🏠"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "street must use Latin-1 characters")
+	})
+
+	t.Run("invalid supplier postbox  with emoji", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Addresses[0].Street = ""
+		inv.Supplier.Addresses[0].PostOfficeBox = "post 🏠"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "post office box must use Latin-1 characters")
+	})
+
+	t.Run("missing supplier address street and postbox", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Supplier.Addresses[0].Street = ""
+		inv.Supplier.Addresses[0].PostOfficeBox = ""
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "either street or post office box must be set")
+	})
+
+	t.Run("invalid customer address street with Japanese characters", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.Addresses[0].Street = "テスト通り"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "street must use Latin-1 characters")
+	})
+
+	t.Run("multiple address validation errors", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		// Set multiple invalid fields to test comprehensive validation
+		inv.Supplier.Name = "Test 中文"
+		inv.Customer.Name = "Cliente 🎉"
+		inv.Supplier.Addresses[0].Street = "Via Test 🏠"
+		inv.Customer.Addresses[0].Locality = "Città 한국어"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+
+		// Should contain multiple validation errors for Latin-1 violations
+		assert.ErrorContains(t, err, "must use Latin-1 characters")
+
+		// Check that relevant fields are mentioned in the error
+		errStr := err.Error()
+		assert.Contains(t, errStr, "supplier")
+		assert.Contains(t, errStr, "customer")
+	})
+}
+
+func TestRetainedTaxesValidation(t *testing.T) {
+	inv := testInvoiceStandard(t)
+	inv.Lines[0].Taxes = append(inv.Lines[0].Taxes, &tax.Combo{
+		Category: "IRPEF",
+		Percent:  num.NewPercentage(20, 2),
+	})
+	require.NoError(t, inv.Calculate())
+	err := rules.Validate(inv)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), fmt.Sprintf("retained tax combo requires '%s' extension", sdi.ExtKeyRetained))
+	}
+
+	inv = testInvoiceStandard(t)
+	inv.Lines[0].Taxes = append(inv.Lines[0].Taxes, &tax.Combo{
+		Category: "IRPEF",
+		Ext: tax.ExtensionsOf(cbc.CodeMap{
+			sdi.ExtKeyRetained: "A",
+		}),
+		Percent: num.NewPercentage(20, 2),
+	})
+	require.NoError(t, inv.Calculate())
+	require.NoError(t, rules.Validate(inv))
+}
+
+func TestInvoiceLineValidation(t *testing.T) {
+	t.Run("missing item tax addon", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Lines = append(inv.Lines, &bill.Line{
+			Quantity: num.MakeAmount(10, 0),
+			Item: &org.Item{
+				Name:  "Test Item",
+				Price: num.NewAmount(10000, 2),
+			},
+			// No taxes!
+		})
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		require.ErrorContains(t, err, "line must have VAT tax category")
+	})
+
+	t.Run("invalid item tax category", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Lines = append(inv.Lines, &bill.Line{
+			Quantity: num.MakeAmount(10, 0),
+			Item: &org.Item{
+				Name:  "Test Item",
+				Price: num.NewAmount(10000, 2),
+			},
+			Taxes: tax.Set{
+				{
+					Category: "GST",
+					Key:      "standard",
+				},
+			},
+		})
+		// Cannot use inv.Calculate() here because GST is not a valid category in IT regime
+		err := rules.Validate(inv, withSDIContext())
+		require.ErrorContains(t, err, "line must have VAT tax category")
+	})
+
+	t.Run("missing line", func(t *testing.T) {
+		// Nil lines should not cause a panic in SDI rules
+		inv := testInvoiceStandard(t)
+		inv.Lines = []*bill.Line{nil}
+		// Cannot use Calculate() with nil lines; validate directly
+		err := rules.Validate(inv, withSDIContext())
+		// SDI addon shouldn't add errors for nil lines
+		if err != nil {
+			assert.NotContains(t, err.Error(), "IT-SDI-V1-BILL-INVOICE-17")
+		}
+	})
+
+	t.Run("missing line item", func(t *testing.T) {
+		// Nil item should not cause a panic in SDI rules
+		inv := testInvoiceStandard(t)
+		inv.Lines[0].Item = nil
+		// Cannot use Calculate() with nil item; validate directly
+		err := rules.Validate(inv, withSDIContext())
+		// SDI addon shouldn't add item name errors for nil items
+		if err != nil {
+			assert.NotContains(t, err.Error(), "IT-SDI-V1-BILL-INVOICE-18")
+		}
+	})
+
+	t.Run("with invalid item name", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Lines[0].Item.Name = "Test Item €"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		require.ErrorContains(t, err, "item name must use Latin-1 characters")
+	})
+}
+
+func TestOrderingValidation(t *testing.T) {
+	t.Run("despatch without deferred tag", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Ordering = &bill.Ordering{
+			Despatch: []*org.DocumentRef{
+				{
+					Code:      "12345",
+					IssueDate: cal.NewDate(2022, 1, 1),
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "despatch can only be set when invoice has deferred tag")
+	})
+
+	t.Run("despatch with deferred tag and valid data", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(sdi.TagDeferred)
+		inv.Ordering = &bill.Ordering{
+			Despatch: []*org.DocumentRef{
+				{
+					Code:      "12345",
+					IssueDate: cal.NewDate(2022, 1, 1),
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("despatch with deferred tag and valid additional data", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(sdi.TagDeferred)
+		inv.Ordering = &bill.Ordering{
+			Despatch: []*org.DocumentRef{
+				{
+					Code:      "12345",
+					IssueDate: cal.NewDate(2022, 1, 1),
+					Reason:    "Partial shipment",
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("despatch with deferred tag but missing code", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(sdi.TagDeferred)
+		inv.Ordering = &bill.Ordering{
+			Despatch: []*org.DocumentRef{
+				{
+					IssueDate: cal.NewDate(2022, 1, 1),
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		// Code validation is handled by base document reference rules
+		assert.ErrorContains(t, err, "document reference code is required")
+	})
+
+	t.Run("despatch with deferred tag but missing issue date", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(sdi.TagDeferred)
+		inv.Ordering = &bill.Ordering{
+			Despatch: []*org.DocumentRef{
+				{
+					Code: "12345",
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "despatch issue date is required")
+	})
+
+	t.Run("multiple despatch documents with deferred tag", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(sdi.TagDeferred)
+		inv.Ordering = &bill.Ordering{
+			Despatch: []*org.DocumentRef{
+				{
+					Code:      "12345",
+					IssueDate: cal.NewDate(2022, 1, 1),
+				},
+				{
+					Code:      "67890",
+					IssueDate: cal.NewDate(2022, 1, 2),
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("multiple despatch with one invalid", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(sdi.TagDeferred)
+		inv.Ordering = &bill.Ordering{
+			Despatch: []*org.DocumentRef{
+				{
+					Code:      "12345",
+					IssueDate: cal.NewDate(2022, 1, 1),
+				},
+				{
+					Code: "67890",
+					// Missing IssueDate
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "despatch issue date is required")
+	})
+
+	t.Run("nil despatch document", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(sdi.TagDeferred)
+		inv.Ordering = &bill.Ordering{
+			Despatch: []*org.DocumentRef{
+				nil,
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("ordering without despatch", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Ordering = &bill.Ordering{
+			Code: "ORDER-123",
+		}
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("no ordering", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, rules.Validate(inv))
+	})
+}

--- a/addon/extensions.go
+++ b/addon/extensions.go
@@ -1,0 +1,1125 @@
+package sdi
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/pkg/here"
+)
+
+// Italian extension keys required by the Italian tax authority (SDI)
+// and defined as part of the FatturaPA specification.
+const (
+	ExtKeyFiscalRegime cbc.Key = "it-sdi-fiscal-regime"
+	ExtKeyFormat       cbc.Key = "it-sdi-format"
+	ExtKeyDocumentType cbc.Key = "it-sdi-document-type"
+	ExtKeyExempt       cbc.Key = "it-sdi-exempt"
+	ExtKeyRetained     cbc.Key = "it-sdi-retained"
+	ExtKeyPaymentMeans cbc.Key = "it-sdi-payment-means"
+	ExtKeyVATLiability cbc.Key = "it-sdi-vat-liability"
+	ExtKeyFundType     cbc.Key = "it-sdi-fund-type"
+
+	ExtKeyLiquidationState cbc.Key = "it-sdi-liquidation-state"
+	ExtKeyShareholderState cbc.Key = "it-sdi-shareholder-state"
+)
+
+var extensions = []*cbc.Definition{
+	{
+		Key: ExtKeyFormat,
+		Name: i18n.String{
+			i18n.EN: "SDI Transmission Format",
+			i18n.IT: "Formato Trasmissione SDI",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				Code used to describe the transmission format of the invoice. By default
+				the value "FPR12" is used unless the user explicitly sets the value
+				to something else.
+
+				Normally this will only be needed when the invoice is to be sent to governmental
+				bodies and must use the "FPA12" format.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "FPA12",
+				Name: i18n.String{
+					i18n.EN: "Public Administration",
+					i18n.IT: "Pubblica Amministrazione",
+				},
+			},
+			{
+				Code: "FPR12",
+				Name: i18n.String{
+					i18n.EN: "Private Parties (default)",
+					i18n.IT: "Soggetti Privati (predefinito)",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyDocumentType,
+		Name: i18n.String{
+			i18n.EN: "SDI Document Type",
+			i18n.IT: "Tipo Documento SDI",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				Code used to describe the type of document being sent to the SDI. This is
+				used to determine the correct schema to use when validating the document.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "TD01",
+				Name: i18n.String{
+					i18n.EN: "Regular Invoice",
+					i18n.IT: "Fattura",
+				},
+			},
+			{
+				Code: "TD02",
+				Name: i18n.String{
+					i18n.EN: "Advance or down payment on invoice",
+					i18n.IT: "Acconto / anticipo su fattura",
+				},
+			},
+			{
+				Code: "TD03",
+				Name: i18n.String{
+					i18n.EN: "Advance or down payment on freelance invoice",
+					i18n.IT: "Acconto / anticipo su parcella",
+				},
+			},
+			{
+				Code: "TD04",
+				Name: i18n.String{
+					i18n.EN: "Credit Note",
+					i18n.IT: "Nota di credito",
+				},
+			},
+			{
+				Code: "TD05",
+				Name: i18n.String{
+					i18n.EN: "Debit Note",
+					i18n.IT: "Nota di debito",
+				},
+			},
+			{
+				Code: "TD06",
+				Name: i18n.String{
+					i18n.EN: "Freelancer invoice with retained taxes",
+					i18n.IT: "Parcella",
+				},
+			},
+			{
+				Code: "TD07",
+				Name: i18n.String{
+					i18n.EN: "Simplified Invoice",
+					i18n.IT: "Fattura Semplificata",
+				},
+			},
+			{
+				Code: "TD08",
+				Name: i18n.String{
+					i18n.EN: "Simplified Credit Note",
+					i18n.IT: "Nota di credito semplificata",
+				},
+			},
+			{
+				Code: "TD09",
+				Name: i18n.String{
+					i18n.EN: "Simplified Debit Note",
+					i18n.IT: "Nota di debito semplificata",
+				},
+			},
+			{
+				Code: "TD16",
+				Name: i18n.String{
+					i18n.EN: "Reverse charge",
+					i18n.IT: "Integrazione fattura reverse charge interno",
+				},
+			},
+			{
+				Code: "TD17",
+				Name: i18n.String{
+					i18n.EN: "Self-billed Import",
+					i18n.IT: "Integrazione/autofattura per acquisto servizi da estero",
+				},
+			},
+			{
+				Code: "TD18",
+				Name: i18n.String{
+					i18n.EN: "Self-billed EU Goods Import",
+					i18n.IT: "Integrazione per acquisto beni intracomunitari",
+				},
+			},
+			{
+				Code: "TD19",
+				Name: i18n.String{
+					i18n.EN: "Self-billed Goods Import",
+					i18n.IT: "Integrazione/autofattura per acquisto beni ex art.17 c.2 DPR 633/72",
+				},
+			},
+			{
+				Code: "TD20",
+				Name: i18n.String{
+					i18n.EN: "Self-billed Regularization",
+					i18n.IT: "Autofattura per regolarizzazione e integrazione delle fatture - art.6 c.8 d.lgs.471/97 o art.46 c.5 D.L.331/93",
+				},
+			},
+			{
+				Code: "TD21",
+				Name: i18n.String{
+					i18n.EN: "Self-billed invoice when ceiling exceeded",
+					i18n.IT: "Autofattura per splafonamento",
+				},
+			},
+			{
+				Code: "TD22",
+				Name: i18n.String{
+					i18n.EN: "Self-billed for goods extracted from VAT warehouse",
+					i18n.IT: "Estrazione beni da Deposito IVA",
+				},
+			},
+			{
+				Code: "TD23",
+				Name: i18n.String{
+					i18n.EN: "Self-billed for goods extracted from VAT warehouse with VAT payment",
+					i18n.IT: "Estrazione beni da Deposito IVA con versamento IVA",
+				},
+			},
+			{
+				Code: "TD24",
+				Name: i18n.String{
+					i18n.EN: "Deferred invoice ex art.21, c.4, lett. a) DPR 633/72",
+					i18n.IT: "Fattura differita - art.21 c.4 lett. a",
+				},
+			},
+			{
+				Code: "TD25",
+				Name: i18n.String{
+					i18n.EN: "Deferred invoice ex art.21, c.4, third period lett. b) DPR 633/72",
+					i18n.IT: "Fattura differita - art.21 c.4 terzo periodo lett. b",
+				},
+			},
+			{
+				Code: "TD26",
+				Name: i18n.String{
+					i18n.EN: "Sale of depreciable assets and for internal transfers (ex art.36 DPR 633/72",
+					i18n.IT: "Cessione di beni ammortizzabili e per passaggi interni - art.36 DPR 633/72",
+				},
+			},
+			{
+				Code: "TD27",
+				Name: i18n.String{
+					i18n.EN: "Self-billed for self consumption or for free transfer without recourse",
+					i18n.IT: "Fattura per autoconsumo o per cessioni gratuite senza rivalsa",
+				},
+			},
+			{
+				Code: "TD28",
+				Name: i18n.String{
+					i18n.EN: "Purchases from San Marino with VAT (paper invoice)",
+					i18n.IT: "Acquisti da San Marino con IVA (fattura cartacea)",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyFiscalRegime,
+		Name: i18n.String{
+			i18n.EN: "Fiscal Regime Code",
+			i18n.IT: "Codice Regime Fiscale",
+		},
+		Values: []*cbc.Definition{
+			{Code: "RF01", Name: i18n.String{
+				i18n.EN: "Ordinary",
+				i18n.IT: "Regime Ordinario",
+			}},
+			{Code: "RF02", Name: i18n.String{
+				i18n.EN: "Minimum taxpayers (Art. 1, section 96-117, Italian Law 244/07)",
+				i18n.IT: "Regime dei contribuenti minimi (art. 1,c.96-117, L. 244/2007)",
+			}},
+			{Code: "RF04", Name: i18n.String{
+				i18n.EN: "Agriculture and connected activities and fishing (Arts. 34 and 34-bis, Italian Presidential Decree 633/72)",
+				i18n.IT: "Agricoltura e attività connesse e pesca (artt. 34 e 34-bis, D.P.R. 633/1972)",
+			}},
+			{Code: "RF05", Name: i18n.String{
+				i18n.EN: "Sale of salts and tobaccos (Art. 74, section 1, Italian Presidential Decree 633/72)",
+				i18n.IT: "Vendita sali e tabacchi (art. 74, c.1, D.P.R. 633/1972)",
+			}},
+			{Code: "RF06", Name: i18n.String{
+				i18n.EN: "Match sales (Art. 74, section 1, Italian Presidential Decree 633/72)",
+				i18n.IT: "Commercio dei fiammiferi (art. 74, c.1, D.P.R. 633/1972)",
+			}},
+			{Code: "RF07", Name: i18n.String{
+				i18n.EN: "Publishing (Art. 74, section 1, Italian Presidential Decree 633/72)",
+				i18n.IT: "Editoria (art. 74, c.1, D.P.R. 633/1972)",
+			}},
+			{Code: "RF08", Name: i18n.String{
+				i18n.EN: "Management of public telephone services (Art. 74, section 1, Italian Presidential Decree 633/72)",
+				i18n.IT: "Gestione di servizi di telefonia pubblica (art. 74, c.1, D.P.R. 633/1972)",
+			}},
+			{Code: "RF09", Name: i18n.String{
+				i18n.EN: "Resale of public transport and parking documents (Art. 74, section 1, Italian Presidential Decree 633/72)",
+				i18n.IT: "Rivendita di documenti di trasporto pubblico e di sosta (art. 74, c.1, D.P.R. 633/1972)",
+			}},
+			{Code: "RF10", Name: i18n.String{
+				i18n.EN: "Entertainment, gaming and other activities referred to by the tariff attached to Italian Presidential Decree 640/72 (Art. 74, section 6, Italian Presidential Decree 633/72)",
+				i18n.IT: "Intrattenimenti, giochi e altre attività di cui alla tariffa allegata al D.P.R. 640/72 (art. 74, c.6, D.P.R. 633/1972)",
+			}},
+			{Code: "RF11", Name: i18n.String{
+				i18n.EN: "Travel and tourism agencies (Art. 74-ter, Italian Presidential Decree 633/72)",
+				i18n.IT: "Agenzie di viaggi e turismo (art. 74-ter, D.P.R. 633/1972)",
+			}},
+			{Code: "RF12", Name: i18n.String{
+				i18n.EN: "Farmhouse accommodation/restaurants (Art. 5, section 2, Italian law 413/91)",
+				i18n.IT: "Agriturismo (art. 5, c.2, L. 413/1991)",
+			}},
+			{Code: "RF13", Name: i18n.String{
+				i18n.EN: "Door-to-door sales (Art. 25-bis, section 6, Italian Presidential Decree 600/73)",
+				i18n.IT: "Vendite a domicilio (art. 25-bis, c.6, D.P.R. 600/1973)",
+			}},
+			{Code: "RF14", Name: i18n.String{
+				i18n.EN: "Resale of used goods, artworks, antiques or collector's items (Art. 36, Italian Decree Law 41/95)",
+				i18n.IT: "Rivendita di beni usati, di oggetti d’arte, d’antiquariato o da collezione (art. 36, D.L. 41/1995)",
+			}},
+			{Code: "RF15", Name: i18n.String{
+				i18n.EN: "Artwork, antiques or collector's items auction agencies (Art. 40-bis, Italian Decree Law 41/95)",
+				i18n.IT: "Agenzie di vendite all’asta di oggetti d’arte, antiquariato o da collezione (art. 40-bis, D.L. 41/1995)",
+			}},
+			{Code: "RF16", Name: i18n.String{
+				i18n.EN: "VAT paid in cash by P.A. (Art. 6, section 5, Italian Presidential Decree 633/72)",
+				i18n.IT: "IVA per cassa P.A. (art. 6, c.5, D.P.R. 633/1972)",
+			}},
+			{Code: "RF17", Name: i18n.String{
+				i18n.EN: "VAT paid in cash by subjects with business turnover below Euro 200,000 (Art. 7, Italian Decree Law 185/2008)",
+				i18n.IT: "IVA per cassa (art. 32-bis, D.L. 83/2012)",
+			}},
+			{Code: "RF19", Name: i18n.String{
+				i18n.EN: "Flat rate (Art. 1, section 54-89, Italian Law 190/2014)",
+				i18n.IT: "Regime forfettario",
+			}},
+			{Code: "RF18", Name: i18n.String{
+				i18n.EN: "Other",
+				i18n.IT: "Altro",
+			}},
+		},
+	},
+	{
+		// Related to the "Natura" field used for VAT exemptions.
+		Key: ExtKeyExempt,
+		Name: i18n.String{
+			i18n.EN: "Exemption Code",
+			i18n.IT: "Natura Esenzione",
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "N1",
+				Name: i18n.String{
+					i18n.EN: "Excluded pursuant to Art. 15, DPR 633/72",
+					i18n.IT: "Escluse ex. art. 15 del D.P.R. 633/1972",
+				},
+			},
+			{
+				Code: "N2.1",
+				Name: i18n.String{
+					i18n.EN: "Not subject pursuant to Art. 7, DPR 633/72",
+					i18n.IT: "Non soggette ex. art. 7 del D.P.R. 633/72",
+				},
+			},
+			{
+				Code: "N2.2",
+				Name: i18n.String{
+					i18n.EN: "Not subject - other",
+					i18n.IT: "Non soggette - altri casi",
+				},
+			},
+			{
+				Code: "N3.1",
+				Name: i18n.String{
+					i18n.EN: "Not taxable - exports",
+					i18n.IT: "Non imponibili - esportazioni",
+				},
+			},
+			{
+				Code: "N3.2",
+				Name: i18n.String{
+					i18n.EN: "Not taxable - intra-community supplies",
+					i18n.IT: "Non imponibili - cessioni intracomunitarie",
+				},
+			},
+			{
+				Code: "N3.3",
+				Name: i18n.String{
+					i18n.EN: "Not taxable - transfers to San Marino",
+					i18n.IT: "Non imponibili - cessioni verso San Marino",
+				},
+			},
+			{
+				Code: "N3.4",
+				Name: i18n.String{
+					i18n.EN: "Not taxable - export supplies of goods and services",
+					i18n.IT: "Non Imponibili - operazioni assimilate alle cessioni all'esportazione",
+				},
+			},
+			{
+				Code: "N3.5",
+				Name: i18n.String{
+					i18n.EN: "Not taxable - declaration of intent",
+					i18n.IT: "Non imponibili - dichiarazioni d'intento",
+				},
+			},
+			{
+				Code: "N3.6",
+				Name: i18n.String{
+					i18n.EN: "Not taxable - other",
+					i18n.IT: "Non imponibili - altre operazioni che non concorrono alla formazione del plafond",
+				},
+			},
+			{
+				Code: "N4",
+				Name: i18n.String{
+					i18n.EN: "Exempt",
+					i18n.IT: "Esenti",
+				},
+			},
+			{
+				Code: "N5",
+				Name: i18n.String{
+					i18n.EN: "Margin regime / VAT not exposed",
+					i18n.IT: "Regime del margine/IVA non esposta in fattura",
+				},
+			},
+			{
+				Code: "N6.1",
+				Name: i18n.String{
+					i18n.EN: "Reverse charge - Transfer of scrap and of other recyclable materials",
+					i18n.IT: "Inversione contabile - cessione di rottami e altri materiali di recupero",
+				},
+			},
+			{
+				Code: "N6.2",
+				Name: i18n.String{
+					i18n.EN: "Reverse charge - Transfer of gold and pure silver pursuant to law 7/2000 as well as used jewelery to OPO",
+					i18n.IT: "Inversione contabile - cessione di oro e argento ai sensi della legge 7/2000 nonché di oreficeria usata ad OPO",
+				},
+			},
+			{
+				Code: "N6.3",
+				Name: i18n.String{
+					i18n.EN: "Reverse charge - Construction subcontracting",
+					i18n.IT: "Inversione contabile - subappalto nel settore edile",
+				},
+			},
+			{
+				Code: "N6.4",
+				Name: i18n.String{
+					i18n.EN: "Reverse charge - Transfer of buildings",
+					i18n.IT: "Inversione contabile - cessione di fabbricati",
+				},
+			},
+			{
+				Code: "N6.5",
+				Name: i18n.String{
+					i18n.EN: "Reverse charge - Transfer of mobile phones",
+					i18n.IT: "Inversione contabile - cessione di telefoni cellulari",
+				},
+			},
+			{
+				Code: "N6.6",
+				Name: i18n.String{
+					i18n.EN: "Reverse charge - Transfer of electronic products",
+					i18n.IT: "Inversione contabile - cessione di prodotti elettronici",
+				},
+			},
+			{
+				Code: "N6.7",
+				Name: i18n.String{
+					i18n.EN: "Reverse charge - provisions in the construction and related sectors",
+					i18n.IT: "Inversione contabile - prestazioni comparto edile e settori connessi",
+				},
+			},
+			{
+				Code: "N6.8",
+				Name: i18n.String{
+					i18n.EN: "Reverse charge - transactions in the energy sector",
+					i18n.IT: "Inversione contabile - operazioni settore energetico",
+				},
+			},
+			{
+				Code: "N6.9",
+				Name: i18n.String{
+					i18n.EN: "Reverse charge - other cases",
+					i18n.IT: "Inversione contabile - altri casi",
+				},
+			},
+			{
+				Code: "N7",
+				Name: i18n.String{
+					i18n.EN: "VAT paid in other EU countries (telecommunications, tele-broadcasting and electronic services provision pursuant to Art. 7 -octies letter a, b, art. 74-sexies Italian Presidential Decree 633/72)",
+					i18n.IT: "IVA assolta in altro stato UE (prestazione di servizi di telecomunicazioni, tele-radiodiffusione ed elettronici ex art. 7-octies lett. a, b, art. 74-sexies DPR 633/72)",
+				},
+			},
+		},
+	},
+	{
+		// Retained reason code determined from the "CausalePagamento" field from FatturaPA.
+		// Source: https://www.agenziaentrate.gov.it/portale/documents/20143/4115385/CU_istr_2022.pdf
+		// Section VII, Part 2
+		Key: ExtKeyRetained,
+		Name: i18n.String{
+			i18n.EN: "Retained Tax Payment Reason Code",
+			i18n.IT: "Causale Pagamento Ritenuta",
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "A",
+				Name: i18n.String{
+					i18n.EN: "Self-employment services falling within the exercise of habitual art or profession",
+					i18n.IT: "Prestazioni di lavoro autonomo rientranti nell'esercizio di arte o professione abituale;",
+				},
+			},
+			{
+				Code: "B",
+				Name: i18n.String{
+					i18n.EN: "Economic use of intellectual works, industrial patents, and processes, formulas or information related to experiences gained in the industrial, commercial or scientific field, by the author or inventor",
+					i18n.IT: "Utilizzazione economica, da parte dell'autore o dell'inventore, di opere dell'ingegno, di brevetti industriali e di processi, formule o informazioni relativi ad esperienze acquisite in campo industriale, commerciale o scientifico;",
+				},
+			},
+			{
+				Code: "C",
+				Name: i18n.String{
+					i18n.EN: "Profits deriving from contracts of association in participation and from contracts of co-interest, when the contribution consists exclusively of the provision of labor",
+					i18n.IT: "Utili derivanti da contratti di associazione in partecipazione e da contratti di cointeressenza, quando l'apporto è costituito esclusivamente dalla prestazione di lavoro;",
+				},
+			},
+			{
+				Code: "D",
+				Name: i18n.String{
+					i18n.EN: "Profits due to the promoting partners and founding partners of capital companies",
+					i18n.IT: "Utili spettanti ai soci promotori ed ai soci fondatori delle società di capitali;",
+				},
+			},
+			{
+				Code: "E",
+				Name: i18n.String{
+					i18n.EN: "Bills of exchange protests levied by municipal secretaries",
+					i18n.IT: "Levata di protesti cambiari da parte dei segretari comunali;",
+				},
+			},
+			{
+				Code: "F",
+				Name: i18n.String{
+					i18n.EN: "Allowances paid to honorary justices of the peace and honorary deputy prosecutors",
+					i18n.IT: "Indennità corrisposte ai giudici onorari di pace e ai vice procuratori onorari;",
+				},
+			},
+			{
+				Code: "G",
+				Name: i18n.String{
+					i18n.EN: "Allowances paid for the cessation of professional sports activities",
+					i18n.IT: "Indennità corrisposte per la cessazione di attività sportiva professionale",
+				},
+			},
+			{
+				Code: "H",
+				Name: i18n.String{
+					i18n.EN: "Allowances paid for the termination of agency relationships of individuals and partnerships, excluding amounts accrued up to December 31, 2003, already allocated for competence and taxed as business income",
+					i18n.IT: "Indennità corrisposte per la cessazione dei rapporti di agenzia delle persone fisiche e delle società di persone con esclusione delle somme maturate entro il 31 dicembre 2003, già imputate per competenza e tassate come reddito d'impresa",
+				},
+			},
+			{
+				Code: "I",
+				Name: i18n.String{
+					i18n.EN: "Allowances paid for the cessation of notarial functions",
+					i18n.IT: "Indennità corrisposte per la cessazione da funzioni notarili",
+				},
+			},
+			{
+				Code: "J",
+				Name: i18n.String{
+					i18n.EN: "Fees paid to occasional truffle collectors not identified for value-added tax purposes, in relation to the sale of truffles",
+					i18n.IT: "Compensi corrisposti ai raccoglitori occasionali di tartufi non identificati ai fini dell'imposta sul valore aggiunto, in relazione alla cessione di tartufi",
+				},
+			},
+			{
+				Code: "K",
+				Name: i18n.String{
+					i18n.EN: "Universal civil service checks referred to in Article 16 of Legislative Decree no. 40 of March 6, 2017",
+					i18n.IT: "Assegni di servizio civile universale di cui all'art.16 del d.lgs. n. 40 del 6 marzo 2017", //nolint:misspell
+				},
+			},
+			{
+				Code: "L",
+				Name: i18n.String{
+					i18n.EN: "Income deriving from the economic use of intellectual works, industrial patents, and processes, formulas, and information related to experiences gained in the industrial, commercial or scientific field, which are received by those entitled free of charge (e.g. heirs and legatees of the author and inventor)",
+					i18n.IT: "Redditi derivanti dall'utilizzazione economica di opere dell'ingegno, di brevetti industriali e di processi, formule e informazioni relativi a esperienze acquisite in campo industriale, commerciale o scientifico, che sono percepiti dagli aventi causa a titolo gratuito (ad es. eredi e legatari dell'autore e inventore)",
+				},
+			},
+			{
+				Code: "L1",
+				Name: i18n.String{
+					i18n.EN: "Income deriving from the economic use of intellectual works, industrial patents, and processes, formulas, and information related to experiences gained in the industrial, commercial or scientific field, which are received by subjects who have purchased the rights to their use for valuable consideration",
+					i18n.IT: "Redditi derivanti dall'utilizzazione economica di opere dell'ingegno, di brevetti industriali e di processi, formule e informazioni relativi a esperienze acquisite in campo industriale, commerciale o scientifico, che sono percepiti da soggetti che abbiano acquistato a titolo oneroso i diritti alla loro utilizzazione",
+				},
+			},
+			{
+				Code: "M",
+				Name: i18n.String{
+					i18n.EN: "Self-employment services not carried out habitually",
+					i18n.IT: "Prestazioni di lavoro autonomo non esercitate abitualmente",
+				},
+			},
+			{
+				Code: "M1",
+				Name: i18n.String{
+					i18n.EN: "Income deriving from the assumption of obligations to do, not to do, or to allow",
+					i18n.IT: "Redditi derivanti dall'assunzione di obblighi di fare, di non fare o permettere",
+				},
+			},
+			{
+				Code: "M2",
+				Name: i18n.String{
+					i18n.EN: "Self-employment services not carried out habitually for which there is an obligation to register with the Separate ENPAPI Management",
+					i18n.IT: "Prestazioni di lavoro autonomo non esercitate abitualmente per le quali sussiste l'obbligo di iscrizione alla gestione separata enpapi",
+				},
+			},
+			{
+				Code: "N",
+				Name: i18n.String{
+					i18n.EN: "Travel allowances, flat-rate reimbursement of expenses, prizes, and fees paid: - in the direct exercise of amateur sports activities; - in relation to coordinated and continuous collaboration relationships of an administrative-managerial nature, not professional, provided in favor of amateur sports companies and associations, and choirs, bands, and amateur theater groups by the director and technical collaborators",
+					i18n.IT: "Indennità di trasferta, rimborso forfetario di spese, premi e compensi erogati: - nell'esercizio diretto di attività sportive dilettantistiche; - in relazione a rapporti di collaborazione coordinata e continuativa di carattere amministrativo-gestionale di natura non professionale resi a favore di società e associazioni sportive dilettantistiche e di cori, bande e filodrammatiche da parte del direttore e dei collaboratori tecnici;",
+				},
+			},
+			{
+				Code: "O",
+				Name: i18n.String{
+					i18n.EN: "Self-employment services not carried out habitually, for which there is no obligation to register with the separate management (Circ. INPS n. 104/2001)",
+					i18n.IT: "Prestazioni di lavoro autonomo non esercitate abitualmente, per le quali non sussiste l'obbligo di iscrizione alla gestione separata (circ. inps n. 104/2001)",
+				},
+			},
+			{
+				Code: "O1",
+				Name: i18n.String{
+					i18n.EN: "Income deriving from the assumption of obligations to do, not to do, or to allow, for which there is no obligation to register with the separate management (Circ. INPS n. 104/2001)",
+					i18n.IT: "Redditi derivanti dall'assunzione di obblighi di fare, di non fare o permettere, per le quali non sussiste l'obbligo di iscrizione alla gestione separata (circ. inps n. 104/2001)",
+				},
+			},
+			{
+				Code: "P",
+				Name: i18n.String{
+					i18n.EN: "Fees paid to non-resident subjects without a permanent establishment for the use or concession of use of industrial, commercial or scientific equipment located in the State's territory or to Swiss companies or permanent establishments of Swiss companies meeting the requirements of Article 15, paragraph 2 of the Agreement between the European Community and the Swiss Confederation of October 26, 2004 (published in G.U.C.E. of December 29, 2004, no. L385/30)",
+					i18n.IT: "Compensi corrisposti a soggetti non residenti privi di stabile organizzazione per l'uso o la concessione in uso di attrezzature industriali, commerciali o scientifiche che si trovano nel territorio dello stato ovvero a società svizzere o stabili organizzazioni di società svizzere che possiedono i requisiti di cui all'art. 15, comma 2 dell'accordo tra la comunità europea e la confederazione svizzera del 26 ottobre 2004 (pubblicato in g.u.c.e. del 29 dicembre 2004 n. l385/30)",
+				},
+			},
+			{
+				Code: "Q",
+				Name: i18n.String{
+					i18n.EN: "Commissions paid to a single-mandate agent or commercial representative",
+					i18n.IT: "Provvigioni corrisposte ad agente o rappresentante di commercio monomandatario",
+				},
+			},
+			{
+				Code: "R",
+				Name: i18n.String{
+					i18n.EN: "Commissions paid to a multi-mandate agent or commercial representative",
+					i18n.IT: "Provvigioni corrisposte ad agente o rappresentante di commercio plurimandatario",
+				},
+			},
+			{
+				Code: "S",
+				Name: i18n.String{
+					i18n.EN: "Commissions paid to a commission agent",
+					i18n.IT: "Provvigioni corrisposte a commissionario",
+				},
+			},
+			{
+				Code: "T",
+				Name: i18n.String{
+					i18n.EN: "Commissions paid to a broker",
+					i18n.IT: "Provvigioni corrisposte a mediatore",
+				},
+			},
+			{
+				Code: "U",
+				Name: i18n.String{
+					i18n.EN: "Commissions paid to a business finder",
+					i18n.IT: "Provvigioni corrisposte a procacciatore di affari",
+				},
+			},
+			{
+				Code: "V",
+				Name: i18n.String{
+					i18n.EN: "Commissions paid to a home sales agent; commissions paid to an agent for door-to-door and street sales of daily newspapers and periodicals (Law of February 25, 1987, no. 67)",
+					i18n.IT: "Provvigioni corrisposte a incaricato per le vendite a domicilio; provvigioni corrisposte a incaricato per la vendita porta a porta e per la vendita ambulante di giornali quotidiani e periodici (l. 25 febbraio 1987, n. 67);",
+				},
+			},
+			{
+				Code: "V1",
+				Name: i18n.String{
+					i18n.EN: "Income deriving from non-habitual commercial activities (e.g. commissions paid for occasional services to agents or commercial representatives, brokers, business finders)",
+					i18n.IT: "Redditi derivanti da attività commerciali non esercitate abitualmente (ad esempio, provvigioni corrisposte per prestazioni occasionali ad agente o rappresentante di commercio, mediatore, procacciatore d'affari);",
+				},
+			},
+			{
+				Code: "V2",
+				Name: i18n.String{
+					i18n.EN: "Income from non-habitual services provided by direct home sales agents",
+					i18n.IT: "Redditi derivanti dalle prestazioni non esercitate abitualmente rese dagli incaricati alla vendita diretta a domicilio;",
+				},
+			},
+			{
+				Code: "W",
+				Name: i18n.String{
+					i18n.EN: "Considerations paid in 2021 for services related to subcontracting contracts to which the provisions contained in Article 25-ter of Presidential Decree no. 600 of September 29, 1973, have been applied",
+					i18n.IT: "Corrispettivi erogati nel 2021 per prestazioni relative a contratti d'appalto cui si sono resi applicabili le disposizioni contenute nell'art. 25-ter del d.p.r. n. 600 del 29 settembre 1973;",
+				},
+			},
+			{
+				Code: "X",
+				Name: i18n.String{
+					i18n.EN: "Fees paid in 2004 by resident companies or entities or by permanent establishments of foreign companies referred to in Article 26-quater, paragraph 1, letters a) and b) of Presidential Decree 600 of September 29, 1973, to companies or permanent establishments of companies located in another EU Member State meeting the requirements of the aforementioned Article 26-quater of Presidential Decree 600 of September 29, 1973, for which a refund of the withholding tax was made in 2006 pursuant to Article 4 of Legislative Decree no. 143 of May 30, 2005",
+					i18n.IT: "Canoni corrisposti nel 2004 da società o enti residenti ovvero da stabili organizzazioni di società estere di cui all'art. 26-quater, comma 1, lett. a) e b) del d.p.r. 600 del 29 settembre 1973, a società o stabili organizzazioni di società, situate in altro stato membro dell'unione europea in presenza dei requisiti di cui al citato art. 26-quater, del d.p.r. 600 del 29 settembre 1973, per i quali è stato effettuato, nell'anno 2006, il rimborso della ritenuta ai sensi dell'art. 4 del d.lgs. 30 maggio 2005 n. 143;",
+				},
+			},
+			{
+				Code: "Y",
+				Name: i18n.String{
+					i18n.EN: "Fees paid from January 1, 2005, to July 26, 2005, by resident companies or entities or by permanent establishments of foreign companies referred to in Article 26-quater, paragraph 1, letters a) and b) of Presidential Decree no. 600 of September 29, 1973, to companies or permanent establishments of companies located in another EU Member State meeting the requirements of the aforementioned Article 26-quater of Presidential Decree 600 of September 29, 1973, for which a refund of the withholding tax was made in 2006 pursuant to Article 4 of Legislative Decree no. 143 of May 30, 2005",
+					i18n.IT: "Canoni corrisposti dal 1° gennaio 2005 al 26 luglio 2005 da società o enti residenti ovvero da stabili organizzazioni di società estere di cui all'art. 26-quater, comma 1, lett. a) e b) del d.p.r. n. 600 del 29 settembre 1973, a società o stabili organizzazioni di società, situate in altro stato membro dell'unione europea in presenza dei requisiti di cui al citato art. 26-quater, del d.p.r. n. 600 del 29 settembre 1973, per i quali è stato effettuato, nell'anno 2006, il rimborso della ritenuta ai sensi dell'art. 4 del d.lgs. 30 maggio 2005 n. 143;",
+				},
+			},
+			{
+				Code: "ZO",
+				Name: i18n.String{
+					i18n.EN: "Different title from the previous ones",
+					i18n.IT: "Titolo diverso dai precedenti;",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyPaymentMeans,
+		Name: i18n.String{
+			i18n.EN: "Payment Means",
+			i18n.IT: "Modalità di Pagamento",
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "MP01",
+				Name: i18n.String{
+					i18n.EN: "Cash",
+					i18n.IT: "Contanti",
+				},
+			},
+			{
+				Code: "MP02",
+				Name: i18n.String{
+					i18n.EN: "Check",
+					i18n.IT: "Assegno",
+				},
+			},
+			{
+				Code: "MP03",
+				Name: i18n.String{
+					i18n.EN: "Banker's Draft",
+					i18n.IT: "Assegno circolare",
+				},
+			},
+			{
+				Code: "MP04",
+				Name: i18n.String{
+					i18n.EN: "Cash at Treasury",
+					i18n.IT: "Contanti presso Tesoreria", // nolint:misspell
+				},
+			},
+			{
+				Code: "MP05",
+				Name: i18n.String{
+					i18n.EN: "Bank Transfer",
+					i18n.IT: "Bonifico",
+				},
+			},
+			{
+				Code: "Mp06",
+				Name: i18n.String{
+					i18n.EN: "Promissory Note",
+					i18n.IT: "Vaglia cambiario",
+				},
+			},
+			{
+				Code: "MP07",
+				Name: i18n.String{
+					i18n.EN: "Bank payment slip",
+					i18n.IT: "Bollettino bancario",
+				},
+			},
+			{
+				Code: "MP08",
+				Name: i18n.String{
+					i18n.EN: "Payment card",
+					i18n.IT: "Carta di pagamento",
+				},
+			},
+			{
+				Code: "MP09",
+				Name: i18n.String{
+					i18n.EN: "Direct Debit (RID)",
+					i18n.IT: "RID",
+				},
+			},
+			{
+				Code: "MP10",
+				Name: i18n.String{
+					i18n.EN: "Utilities Direct Debit (RID utenze)",
+					i18n.IT: "RID utenze",
+				},
+			},
+			{
+				Code: "MP11",
+				Name: i18n.String{
+					i18n.EN: "Fast Direct Debit (RID veloce)",
+					i18n.IT: "RID veloce",
+				},
+			},
+			{
+				Code: "MP12",
+				Name: i18n.String{
+					i18n.EN: "Direct Debit (RIBA)",
+					i18n.IT: "RIBA",
+				},
+			},
+			{
+				Code: "MP13",
+				Name: i18n.String{
+					i18n.EN: "Debit Transfer (MAV)",
+					i18n.IT: "MAV",
+				},
+			},
+			{
+				Code: "MP14",
+				Name: i18n.String{
+					i18n.EN: "Tax Receipt",
+					i18n.IT: "Quietanza erario",
+				},
+			},
+			{
+				Code: "MP15",
+				Name: i18n.String{
+					i18n.EN: "Transfer on special account",
+					i18n.IT: "Giroconto su conti di contabilità speciale",
+				},
+			},
+			{
+				Code: "MP16",
+				Name: i18n.String{
+					i18n.EN: "Direct Debit",
+					i18n.IT: "Domiciliazione Bancaria",
+				},
+			},
+			{
+				Code: "MP17",
+				Name: i18n.String{
+					i18n.EN: "Direct Debit Post Office",
+					i18n.IT: "Domiciliazione Postale",
+				},
+			},
+			{
+				Code: "MP18",
+				Name: i18n.String{
+					i18n.EN: "Post Office Cheque",
+					i18n.IT: "Bollettino di c/c postale",
+				},
+			},
+			{
+				Code: "MP19",
+				Name: i18n.String{
+					i18n.EN: "SEPA Direct Debit",
+					i18n.IT: "SEPA Direct Debit",
+				},
+			},
+			{
+				Code: "MP20",
+				Name: i18n.String{
+					i18n.EN: "SEPA Core Direct Debit",
+					i18n.IT: "SEPA Direct Debit Core",
+				},
+			},
+			{
+				Code: "MP21",
+				Name: i18n.String{
+					i18n.EN: "SEPA B2B Direct Debit",
+					i18n.IT: "SEPA Direct Debit B2B",
+				},
+			},
+			{
+				Code: "MP22",
+				Name: i18n.String{
+					i18n.EN: "Deductible Netting",
+					i18n.IT: "Trattenuta su somme già riscosse",
+				},
+			},
+			{
+				Code: "MP23",
+				Name: i18n.String{
+					i18n.EN: "PagoPA",
+					i18n.IT: "PagoPA",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyVATLiability,
+		Name: i18n.String{
+			i18n.EN: "VAT Liability",
+			i18n.IT: "Esigibilità dell'IVA",
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "I",
+				Name: i18n.String{
+					i18n.EN: "Immediate",
+					i18n.IT: "Immediata",
+				},
+			},
+			{
+				Code: "D",
+				Name: i18n.String{
+					i18n.EN: "Deferred",
+					i18n.IT: "Differita",
+				},
+			},
+			{
+				Code: "S",
+				Name: i18n.String{
+					i18n.EN: "Split Payment",
+					i18n.IT: "Scissione dei pagamenti",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyFundType,
+		Name: i18n.String{
+			i18n.EN: "Fund Type",
+			i18n.IT: "Tipo Cassa",
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "TC01",
+				Name: i18n.String{
+					i18n.EN: "National Pension and Welfare Fund for Lawyers and Solicitors",
+					i18n.IT: "Cassa nazionale di previdenza e assistenza forense",
+				},
+			},
+			{
+				Code: "TC02",
+				Name: i18n.String{
+					i18n.EN: "Pension fund for accountants",
+					i18n.IT: "Cassa di previdenza dottori commercialisti",
+				},
+			},
+			{
+				Code: "TC03",
+				Name: i18n.String{
+					i18n.EN: "Pension and welfare fund for surveyors",
+					i18n.IT: "Cassa di previdenza e assistenza geometri",
+				},
+			},
+			{
+				Code: "TC04",
+				Name: i18n.String{
+					i18n.EN: "National pension and welfare fund for self-employed engineers and architects",
+					i18n.IT: "Cassa nazionale di previdenza e assistenza per gli ingegneri e gli architetti liberi professionisti",
+				},
+			},
+			{
+				Code: "TC05",
+				Name: i18n.String{
+					i18n.EN: "National fund for solicitors",
+					i18n.IT: "Cassa nazionale del notariato",
+				},
+			},
+			{
+				Code: "TC06",
+				Name: i18n.String{
+					i18n.EN: "National pension and welfare fund for bookkeepers and commercial experts",
+					i18n.IT: "Cassa nazionale di previdenza e assistenza ragionieri e periti commerciali",
+				},
+			},
+			{
+				Code: "TC07",
+				Name: i18n.String{
+					i18n.EN: "National welfare board for sales agents and representatives (ENASARCO)",
+					i18n.IT: "Ente nazionale assistenza agenti e rappresentanti di commercio (ENASARCO)",
+				},
+			},
+			{
+				Code: "TC08",
+				Name: i18n.String{
+					i18n.EN: "National pension and welfare board for employment consultants (ENPACL)",
+					i18n.IT: "Ente nazionale di previdenza e assistenza consulenti del lavoro (ENPACL)",
+				},
+			},
+			{
+				Code: "TC09",
+				Name: i18n.String{
+					i18n.EN: "National pension and welfare board for doctors (ENPAM)",
+					i18n.IT: "Ente nazionale di previdenza e assistenza medici (ENPAM)",
+				},
+			},
+			{
+				Code: "TC10",
+				Name: i18n.String{
+					i18n.EN: "National pension and welfare board for pharmacists (ENPAF)",
+					i18n.IT: "Ente nazionale di previdenza e assistenza farmacisti (ENPAF)",
+				},
+			},
+			{
+				Code: "TC11",
+				Name: i18n.String{
+					i18n.EN: "National pension and welfare board for veterinary physicians (ENPAV)",
+					i18n.IT: "Ente nazionale di previdenza e assistenza veterinari (ENPAV)",
+				},
+			},
+			{
+				Code: "TC12",
+				Name: i18n.String{
+					i18n.EN: "National pension and welfare board for agricultural employees (ENPAIA)",
+					i18n.IT: "Ente nazionale di previdenza e assistenza per i periti industriali e i periti industriali laureati (ENPAIA)",
+				},
+			},
+			{
+				Code: "TC13",
+				Name: i18n.String{
+					i18n.EN: "Pension fund for employees of shipping companies and maritime agencies",
+					i18n.IT: "Cassa di previdenza per l'assicurazione degli impiegati presso le aziende di navigazione ed i consorzi di armatori per il lavoro portuale",
+				},
+			},
+			{
+				Code: "TC14",
+				Name: i18n.String{
+					i18n.EN: "National pension institute for Italian journalists (INPGI)",
+					i18n.IT: "Istituto nazionale di previdenza dei giornalisti italiani (INPGI)",
+				},
+			},
+			{
+				Code: "TC15",
+				Name: i18n.String{
+					i18n.EN: "National welfare board for orphans of Italian doctors (ONAOSI)",
+					i18n.IT: "Opera nazionale per l'assistenza degli orfani dei sanitari italiani (ONAOSI)",
+				},
+			},
+			{
+				Code: "TC16",
+				Name: i18n.String{
+					i18n.EN: "Autonomous supplementary welfare fund for Italian journalists (CASAGIT)",
+					i18n.IT: "Cassa autonoma di assistenza integrativa dei giornalisti italiani (CASAGIT)",
+				},
+			},
+			{
+				Code: "TC17",
+				Name: i18n.String{
+					i18n.EN: "Pension board for industrial experts and graduate industrial experts (EPPI)",
+					i18n.IT: "Ente di previdenza periti industriali e periti industriali laureati (EPPI)",
+				},
+			},
+			{
+				Code: "TC18",
+				Name: i18n.String{
+					i18n.EN: "National multi-category pension and welfare board (EPAP)",
+					i18n.IT: "Ente di previdenza e assistenza pluricategoriale (EPAP)",
+				},
+			},
+			{
+				Code: "TC19",
+				Name: i18n.String{
+					i18n.EN: "National pension and welfare board for biologists (ENPAB)",
+					i18n.IT: "Ente nazionale di previdenza e assistenza biologi (ENPAB)",
+				},
+			},
+			{
+				Code: "TC20",
+				Name: i18n.String{
+					i18n.EN: "National pension and welfare board for the nursing profession (ENPAPI)",
+					i18n.IT: "Ente nazionale di previdenza e assistenza professione infermieristica (ENPAPI)",
+				},
+			},
+			{
+				Code: "TC21",
+				Name: i18n.String{
+					i18n.EN: "National pension and welfare board for psychologists (ENPAP)",
+					i18n.IT: "Ente nazionale di previdenza e assistenza psicologi (ENPAP)",
+				},
+			},
+			{
+				Code: "TC22",
+				Name: i18n.String{
+					i18n.EN: "National Social Security Institute (INPS)",
+					i18n.IT: "Istituto nazionale della previdenza sociale (INPS)",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyLiquidationState,
+		Name: i18n.String{
+			i18n.EN: "Liquidation State",
+			i18n.IT: "Stato di Liquidazione",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				Indicates whether the company is in liquidation, used in the
+				IscrizioneREA block of a FatturaPA document as the
+				StatoLiquidazione field.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "LS",
+				Name: i18n.String{
+					i18n.EN: "In liquidation",
+					i18n.IT: "In liquidazione",
+				},
+			},
+			{
+				Code: "LN",
+				Name: i18n.String{
+					i18n.EN: "Not in liquidation",
+					i18n.IT: "Non in liquidazione",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyShareholderState,
+		Name: i18n.String{
+			i18n.EN: "Shareholder State",
+			i18n.IT: "Stato di Socio",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				Indicates the company's shareholder configuration, used in the
+				IscrizioneREA block of a FatturaPA document as the SocioUnico
+				field.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "SU",
+				Name: i18n.String{
+					i18n.EN: "Sole shareholder",
+					i18n.IT: "Socio unico",
+				},
+			},
+			{
+				Code: "SM",
+				Name: i18n.String{
+					i18n.EN: "Multiple shareholders",
+					i18n.IT: "Più soci",
+				},
+			},
+		},
+	},
+}

--- a/addon/identities.go
+++ b/addon/identities.go
@@ -1,0 +1,10 @@
+package sdi
+
+import "github.com/invopop/gobl/cbc"
+
+const (
+	// IdentityTypeCUP defines code managed by the CIPE (Interministerial Committee for Economic Planning) which characterises every public investment project (Individual Project Code)
+	IdentityTypeCUP cbc.Code = "CUP"
+	// IdentityTypeCIG defines tender procedure identification code.
+	IdentityTypeCIG cbc.Code = "CIG"
+)

--- a/addon/inboxes.go
+++ b/addon/inboxes.go
@@ -1,0 +1,29 @@
+package sdi
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+)
+
+// Inbox keys to universally identify where copies of documents can be sent.
+const (
+	KeyInboxCode cbc.Key = "it-sdi-code"
+	KeyInboxPEC  cbc.Key = "it-sdi-pec"
+)
+
+var inboxes = []*cbc.Definition{
+	{
+		Key: KeyInboxCode,
+		Name: i18n.String{
+			i18n.EN: "SDI Destination Code",
+			i18n.IT: "Codice Destinatario SDI",
+		},
+	},
+	{
+		Key: KeyInboxPEC,
+		Name: i18n.String{
+			i18n.EN: "SDI PEC Destination",
+			i18n.IT: "PEC Destinatario SDI",
+		},
+	},
+}

--- a/addon/invoice_scenarios_test.go
+++ b/addon/invoice_scenarios_test.go
@@ -1,0 +1,82 @@
+package sdi_test
+
+import (
+	"testing"
+
+	sdi "github.com/invopop/gobl.fatturapa/addon"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func scenarioInvoice(t *testing.T) *bill.Invoice {
+	t.Helper()
+	return &bill.Invoice{
+		Addons:    tax.WithAddons(sdi.V1),
+		Series:    "TEST",
+		Code:      "00123",
+		IssueDate: cal.MakeDate(2022, 6, 13),
+		Tax: &bill.Tax{
+			PricesInclude: tax.CategoryVAT,
+		},
+		Supplier: &org.Party{
+			Name:  "Test Supplier",
+			TaxID: &tax.Identity{Country: "IT", Code: "12345678903"},
+		},
+		Customer: &org.Party{
+			Name:  "Test Customer",
+			TaxID: &tax.Identity{Country: "IT", Code: "13029381004"},
+		},
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(10, 0),
+				Item:     &org.Item{Name: "Test Item", Price: num.NewAmount(10000, 2)},
+				Taxes:    tax.Set{{Category: "VAT", Rate: "general"}},
+			},
+		},
+	}
+}
+
+func TestInvoiceScenarioExtensions(t *testing.T) {
+	t.Run("document type defaults to TD01", func(t *testing.T) {
+		inv := scenarioInvoice(t)
+		inv.Tax = nil
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, 2, inv.Tax.Ext.Len())
+		assert.Equal(t, "TD01", inv.Tax.Ext.Get(sdi.ExtKeyDocumentType).String())
+	})
+
+	t.Run("B2G overwrites the format to FPA12", func(t *testing.T) {
+		inv := scenarioInvoice(t)
+		inv.SetTags(tax.TagB2G)
+		inv.Tax = &bill.Tax{
+			Ext: tax.ExtensionsOf(cbc.CodeMap{sdi.ExtKeyFormat: "XXXX"}),
+		}
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, 2, inv.Tax.Ext.Len())
+		assert.Equal(t, "FPA12", inv.Tax.Ext.Get(sdi.ExtKeyFormat).String())
+	})
+
+	t.Run("non-B2G overwrites the format to FPR12", func(t *testing.T) {
+		inv := scenarioInvoice(t)
+		inv.Tax = &bill.Tax{
+			Ext: tax.ExtensionsOf(cbc.CodeMap{sdi.ExtKeyFormat: "XXXX"}),
+		}
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, 2, inv.Tax.Ext.Len())
+		assert.Equal(t, "FPR12", inv.Tax.Ext.Get(sdi.ExtKeyFormat).String())
+	})
+}
+
+func TestInvoiceGetExtensions(t *testing.T) {
+	inv := scenarioInvoice(t)
+	require.NoError(t, inv.Calculate())
+	ext := inv.GetExtensions()
+	assert.Len(t, ext, 2)
+	assert.Equal(t, "FPR12", ext[0].Get(sdi.ExtKeyFormat).String())
+}

--- a/addon/org.go
+++ b/addon/org.go
@@ -1,0 +1,56 @@
+package sdi
+
+import (
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+)
+
+func orgAddressRules() *rules.Set {
+	return rules.For(new(org.Address),
+		rules.Assert("01", "address either street or post office box must be set",
+			is.Func("street or postbox", addressHasStreetOrPostBox),
+		),
+		rules.Field("street",
+			rules.Assert("02", "address street must use Latin-1 characters",
+				is.FuncError("latin1", validateLatin1String),
+			),
+		),
+		rules.Field("po_box",
+			rules.Assert("03", "address post office box must use Latin-1 characters",
+				is.FuncError("latin1", validateLatin1String),
+			),
+		),
+		rules.Field("country",
+			rules.Assert("04", "address country is required", is.Present),
+		),
+		rules.Field("locality",
+			rules.Assert("05", "address locality is required", is.Present),
+			rules.Assert("06", "address locality must use Latin-1 characters",
+				is.FuncError("latin1", validateLatin1String),
+			),
+		),
+		rules.When(is.Func("Italian address", addressIsItalian),
+			rules.Field("code",
+				rules.Assert("07", "Italian address code is required", is.Present),
+				rules.Assert("08", "Italian address code must be 5 digits", is.Matches(`^\d{5}$`)),
+			),
+		),
+	)
+}
+
+func addressHasStreetOrPostBox(val any) bool {
+	a, ok := val.(*org.Address)
+	if !ok || a == nil {
+		return true
+	}
+	return a.Street != "" || a.PostOfficeBox != ""
+}
+
+func addressIsItalian(val any) bool {
+	a, ok := val.(*org.Address)
+	if !ok || a == nil {
+		return false
+	}
+	return a.Country.In("IT")
+}

--- a/addon/pay.go
+++ b/addon/pay.go
@@ -1,0 +1,108 @@
+package sdi
+
+import (
+	"fmt"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/pay"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+)
+
+// Regime Specific Payment Means Extension Keys
+const (
+	MeansKeyTreasury       cbc.Key = "treasury"
+	MeansKeyPaymentSlip    cbc.Key = "payment-slip"
+	MeansKeyRID            cbc.Key = "rid"
+	MeansKeyRIDUtility     cbc.Key = "rid-utility"
+	MeansKeyRIDFast        cbc.Key = "rid-fast"
+	MeansKeyRIBA           cbc.Key = "riba"
+	MeansKeyTaxReceipt     cbc.Key = "tax-receipt"
+	MeansKeySpecialAccount cbc.Key = "special-account"
+	MeansKeyPostOffice     cbc.Key = "post-office"
+	MeansKeySEPA           cbc.Key = "sepa"
+	MeansKeySEPACore       cbc.Key = "sepa-core"
+	MeansKeySEPAB2B        cbc.Key = "sepa-b2b"
+	MeansKeyPagoPA         cbc.Key = "pagopa"
+)
+
+// PaymentMeansExtensions returns the mapping of payment means to their
+// extension values used by SDI.
+func PaymentMeansExtensions() tax.Extensions {
+	return tax.ExtensionsOf(paymentMeansKeyMap)
+}
+
+var paymentMeansKeyMap = cbc.CodeMap{
+	pay.MeansKeyCash:                                 "MP01",
+	pay.MeansKeyCheque:                               "MP02",
+	pay.MeansKeyBankDraft:                            "MP03",
+	pay.MeansKeyCash.With(MeansKeyTreasury):          "MP04",
+	pay.MeansKeyCreditTransfer:                       "MP05",
+	pay.MeansKeyPromissoryNote:                       "MP06",
+	pay.MeansKeyOther.With(MeansKeyPaymentSlip):      "MP07",
+	pay.MeansKeyCard:                                 "MP08",
+	pay.MeansKeyOnline:                               "MP08",
+	pay.MeansKeyDirectDebit.With(MeansKeyRID):        "MP09",
+	pay.MeansKeyDirectDebit.With(MeansKeyRIDUtility): "MP10",
+	pay.MeansKeyDirectDebit.With(MeansKeyRIDFast):    "MP11",
+	pay.MeansKeyDirectDebit.With(MeansKeyRIBA):       "MP12",
+	pay.MeansKeyDebitTransfer:                        "MP13",
+	pay.MeansKeyOther.With(MeansKeyTaxReceipt):       "MP14",
+	pay.MeansKeyOther.With(MeansKeySpecialAccount):   "MP15",
+	pay.MeansKeyDirectDebit:                          "MP16",
+	pay.MeansKeyDirectDebit.With(MeansKeyPostOffice): "MP17",
+	pay.MeansKeyCheque.With(MeansKeyPostOffice):      "MP18",
+	pay.MeansKeyDirectDebit.With(MeansKeySEPA):       "MP19",
+	pay.MeansKeyDirectDebit.With(MeansKeySEPACore):   "MP20",
+	pay.MeansKeyDirectDebit.With(MeansKeySEPAB2B):    "MP21",
+	pay.MeansKeyNetting:                              "MP22",
+	pay.MeansKeyOnline.With(MeansKeyPagoPA):          "MP23",
+}
+
+func normalizePayInstructions(instr *pay.Instructions) {
+	if instr == nil {
+		return
+	}
+	extVal := paymentMeansKeyMap.Lookup(instr.Key)
+	if extVal != "" {
+		if instr.Ext.IsZero() {
+			instr.Ext = tax.MakeExtensions()
+		}
+		instr.Ext = instr.Ext.Set(ExtKeyPaymentMeans, extVal)
+	}
+}
+
+func normalizePayRecord(adv *pay.Record) {
+	if adv == nil {
+		return
+	}
+	extVal := paymentMeansKeyMap.Lookup(adv.Key)
+	if extVal != "" {
+		if adv.Ext.IsZero() {
+			adv.Ext = tax.MakeExtensions()
+		}
+		adv.Ext = adv.Ext.Set(ExtKeyPaymentMeans, extVal)
+	}
+}
+
+func payInstructionsRules() *rules.Set {
+	return rules.For(new(pay.Instructions),
+		rules.Field("ext",
+			rules.Assert("01",
+				fmt.Sprintf("payment instructions require '%s' extension", ExtKeyPaymentMeans),
+				tax.ExtensionsRequire(ExtKeyPaymentMeans),
+			),
+		),
+	)
+}
+
+func payAdvanceRules() *rules.Set {
+	return rules.For(new(pay.Record),
+		rules.Field("ext",
+			rules.Assert("01",
+				fmt.Sprintf("payment advance requires '%s' extension", ExtKeyPaymentMeans),
+				tax.ExtensionsRequire(ExtKeyPaymentMeans),
+			),
+		),
+	)
+}

--- a/addon/pay_test.go
+++ b/addon/pay_test.go
@@ -1,0 +1,92 @@
+package sdi_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdi "github.com/invopop/gobl.fatturapa/addon"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/pay"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaymentMeansExtensions(t *testing.T) {
+	m := sdi.PaymentMeansExtensions()
+	assert.False(t, m.IsZero())
+	assert.Equal(t, 24, m.Len())
+	assert.Equal(t, pay.MeansKeyCash, m.Lookup("MP01"))
+}
+
+func TestPayInstructionsNormalize(t *testing.T) {
+	inv := testInvoiceStandard(t)
+	inv.Payment = &bill.PaymentDetails{
+		Instructions: &pay.Instructions{
+			Key: "online",
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				"random": "",
+			}),
+		},
+		Advances: []*pay.Record{
+			{
+				Key:         pay.MeansKeyDirectDebit.With(sdi.MeansKeyRID),
+				Description: "Test advance",
+				Amount:      num.MakeAmount(100, 0),
+				Ext: tax.ExtensionsOf(cbc.CodeMap{
+					"random": "",
+				}),
+			},
+		},
+	}
+	assert.True(t, inv.Payment.Instructions.Ext.Has("random"))
+	assert.True(t, inv.Payment.Advances[0].Ext.Has("random"))
+	assert.NoError(t, inv.Calculate())
+	assert.False(t, inv.Payment.Instructions.Ext.Has("random"))
+	assert.False(t, inv.Payment.Advances[0].Ext.Has("random"))
+}
+
+func TestPayInstructionsValidation(t *testing.T) {
+	inv := testInvoiceStandard(t)
+
+	inv.Payment = &bill.PaymentDetails{
+		Instructions: &pay.Instructions{
+			Key: "cash",
+		},
+		Advances: []*pay.Record{
+			{
+				Key:         pay.MeansKeyDirectDebit.With(sdi.MeansKeyRID),
+				Description: "Test advance",
+				Amount:      num.MakeAmount(100, 0),
+			},
+		},
+	}
+	require.NoError(t, inv.Calculate())
+	err := rules.Validate(inv)
+	require.NoError(t, err)
+
+	inv.Payment = &bill.PaymentDetails{
+		Advances: []*pay.Record{
+			{
+				Key:         cbc.Key("fooo"),
+				Description: "Test advance",
+				Amount:      num.MakeAmount(100, 0),
+			},
+		},
+	}
+	require.NoError(t, inv.Calculate())
+	err = rules.Validate(inv)
+	assert.ErrorContains(t, err, fmt.Sprintf("payment advance requires '%s' extension", sdi.ExtKeyPaymentMeans))
+
+	inv.Payment = &bill.PaymentDetails{
+		Instructions: &pay.Instructions{
+			Key: cbc.Key("fooo"),
+		},
+	}
+	require.NoError(t, inv.Calculate())
+	err = rules.Validate(inv)
+	assert.ErrorContains(t, err, fmt.Sprintf("payment instructions require '%s' extension", sdi.ExtKeyPaymentMeans))
+}

--- a/addon/scenarios.go
+++ b/addon/scenarios.go
@@ -1,0 +1,404 @@
+package sdi
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/tax"
+)
+
+// Document tag keys
+const (
+	// Tags for document type
+	TagFreelance         cbc.Key = "freelance"
+	TagCeilingExceeded   cbc.Key = "ceiling-exceeded"
+	TagSanMarinoPaper    cbc.Key = "san-marino-paper"
+	TagImport            cbc.Key = "import"
+	TagGoods             cbc.Key = "goods"
+	TagGoodsEU           cbc.Key = "goods-eu"
+	TagGoodsWithTax      cbc.Key = "goods-with-tax"
+	TagGoodsExtracted    cbc.Key = "goods-extracted"
+	TagRegularization    cbc.Key = "regularization"
+	TagDeferred          cbc.Key = "deferred"
+	TagThirdPeriod       cbc.Key = "third-period"
+	TagDepreciableAssets cbc.Key = "depreciable-assets"
+)
+
+// This is only a partial list of all the potential tags that
+// could be available for use in Italy. Given the complexity
+// involved, we've focussed here on the most useful.
+var invoiceTags = &tax.TagSet{
+	Schema: bill.ShortSchemaInvoice,
+	List: []*cbc.Definition{
+		// *** Document Type Tags ***
+		// Sales:
+		{
+			Key: tax.TagB2G,
+			Name: i18n.String{
+				i18n.EN: "Business to Government",
+			},
+		},
+		{
+			Key: TagFreelance,
+			Name: i18n.String{
+				i18n.EN: "Freelancer",
+				i18n.IT: "Parcella",
+			},
+		},
+		// Self-billed:
+		{
+			Key: TagCeilingExceeded,
+			Name: i18n.String{
+				i18n.EN: "Ceiling exceeded",
+				i18n.IT: "Splafonamento",
+			},
+		},
+		{
+			Key: TagSanMarinoPaper,
+			Name: i18n.String{
+				i18n.EN: "Purchases from San Marino with VAT and paper invoice",
+				i18n.IT: "Acquisti da San Marino con IVA e fattura cartacea",
+			},
+		},
+		{
+			Key: TagImport,
+			Name: i18n.String{
+				i18n.EN: "Import",
+				i18n.IT: "Importazione",
+			},
+		},
+		{
+			Key: TagGoods,
+			Name: i18n.String{
+				i18n.EN: "Goods",
+				i18n.IT: "Beni",
+			},
+		},
+		{
+			Key: TagGoodsEU,
+			Name: i18n.String{
+				i18n.EN: "Goods from EU",
+				i18n.IT: "Beni da UE",
+			},
+		},
+		{
+			Key: TagGoodsWithTax,
+			Name: i18n.String{
+				i18n.EN: "Goods with tax",
+				i18n.IT: "Beni con imposta",
+			},
+		},
+		{
+			Key: TagGoodsExtracted,
+			Name: i18n.String{
+				i18n.EN: "Goods extracted",
+				i18n.IT: "Beni estratti",
+			},
+		},
+		{
+			Key: TagDeferred,
+			Name: i18n.String{
+				i18n.EN: "Deferred",
+				i18n.IT: "Differita",
+			},
+		},
+		{
+			Key: TagRegularization,
+			Name: i18n.String{
+				i18n.EN: "Regularization",
+				i18n.IT: "Regolarizzazione",
+			},
+		},
+		{
+			Key: TagThirdPeriod,
+			Name: i18n.String{
+				i18n.EN: "Third period",
+				i18n.IT: "Terzo periodo",
+			},
+		},
+		{
+			Key: TagDepreciableAssets,
+			Name: i18n.String{
+				i18n.EN: "Depreciable assets",
+				i18n.IT: "Beni ammortizzabili",
+			},
+		},
+		{
+			Key: tax.TagB2G,
+			Name: i18n.String{
+				i18n.EN: "Business to Government",
+			},
+		},
+	},
+}
+
+var scenarios = []*tax.ScenarioSet{
+	invoiceScenarios,
+}
+
+var invoiceScenarios = &tax.ScenarioSet{
+	Schema: bill.ShortSchemaInvoice,
+	List: []*tax.Scenario{
+		// **** DOCUMENT FORMAT ****
+		{
+			Name: i18n.String{
+				i18n.EN: "Private Invoice",
+				i18n.IT: "Fattura Privata",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyFormat: "FPR12",
+			}),
+		},
+		{
+			Tags: []cbc.Key{tax.TagB2G},
+			Name: i18n.String{
+				i18n.EN: "Government Invoice",
+				i18n.IT: "Fattura Pubblica",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyFormat: "FPA12",
+			}),
+		},
+		// **** TIPO DOCUMENTO ****
+		{
+			// Default
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Name: i18n.String{
+				i18n.EN: "Regular Invoice",
+				i18n.IT: "Fattura",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD01",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagPartial},
+			Name: i18n.String{
+				i18n.EN: "Advance or down payment on invoice",
+				i18n.IT: "Acconto / anticipo su fattura",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD02",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeCreditNote},
+			Name: i18n.String{
+				i18n.EN: "Credit Note",
+				i18n.IT: "Nota di credito",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD04",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeDebitNote},
+			Name: i18n.String{
+				i18n.EN: "Debit Note",
+				i18n.IT: "Nota di debito",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD05",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{TagFreelance},
+			Name: i18n.String{
+				i18n.EN: "Freelancer invoice with retained taxes",
+				i18n.IT: "Parcella",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD06",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagPartial, TagFreelance},
+			Name: i18n.String{
+				i18n.EN: "Advance or down payment on freelance invoice",
+				i18n.IT: "Acconto / anticipo su parcella",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD03",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagSimplified},
+			Name: i18n.String{
+				i18n.EN: "Simplified Invoice",
+				i18n.IT: "Fattura Semplificata",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD07",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeCreditNote},
+			Tags:  []cbc.Key{tax.TagSimplified},
+			Name: i18n.String{
+				i18n.EN: "Simplified Credit Note",
+				i18n.IT: "Nota di credito semplificata",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD08",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeDebitNote},
+			Tags:  []cbc.Key{tax.TagSimplified},
+			Name: i18n.String{
+				i18n.EN: "Simplified Debit Note",
+				i18n.IT: "Nota di debito semplificata",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD09",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagSelfBilled},
+			Name: i18n.String{
+				i18n.EN: "Self-billed for self consumption or for free transfer without recourse",
+				i18n.IT: "Fattura per autoconsumo o per cessioni gratuite senza rivalsa",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD27", // order is important
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagSelfBilled, tax.TagReverseCharge},
+			Name: i18n.String{
+				i18n.EN: "Reverse charge",
+				i18n.IT: "Integrazione fattura reverse charge interno",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD16",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagSelfBilled, TagImport},
+			Name: i18n.String{
+				i18n.EN: "Self-billed Import",
+				i18n.IT: "Integrazione/autofattura per acquisto servizi da estero",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD17",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagSelfBilled, TagImport, TagGoodsEU},
+			Name: i18n.String{
+				i18n.EN: "Self-billed EU Goods Import",
+				i18n.IT: "Integrazione per acquisto beni intracomunitari",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD18",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagSelfBilled, TagImport, TagGoods},
+			Name: i18n.String{
+				i18n.EN: "Self-billed Goods Import",
+				i18n.IT: "Integrazione/autofattura per acquisto beni ex art.17 c.2 DPR 633/72",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD19",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagSelfBilled, TagRegularization},
+			Name: i18n.String{
+				i18n.EN: "Self-billed Regularization",
+				i18n.IT: "Autofattura per regolarizzazione e integrazione delle fatture - art.6 c.8 d.lgs.471/97 o art.46 c.5 D.L.331/93",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD20",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagSelfBilled, TagCeilingExceeded},
+			Name: i18n.String{
+				i18n.EN: "Self-billed invoice when ceiling exceeded",
+				i18n.IT: "Autofattura per splafonamento",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD21",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagSelfBilled, TagGoodsExtracted},
+			Name: i18n.String{
+				i18n.EN: "Self-billed for goods extracted from VAT warehouse",
+				i18n.IT: "Estrazione beni da Deposito IVA",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD22",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagSelfBilled, TagGoodsWithTax},
+			Name: i18n.String{
+				i18n.EN: "Self-billed for goods extracted from VAT warehouse with VAT payment",
+				i18n.IT: "Estrazione beni da Deposito IVA con versamento IVA",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD23",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{TagDeferred},
+			Name: i18n.String{
+				i18n.EN: "Deferred invoice ex art.21, c.4, lett. a) DPR 633/72",
+				i18n.IT: "Fattura differita - art.21 c.4 lett. a",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD24",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{TagDeferred, TagThirdPeriod},
+			Name: i18n.String{
+				i18n.EN: "Deferred invoice ex art.21, c.4, third period lett. b) DPR 633/72",
+				i18n.IT: "Fattura differita - art.21 c.4 terzo periodo lett. b",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD25",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{TagDepreciableAssets},
+			Name: i18n.String{
+				i18n.EN: "Sale of depreciable assets and for internal transfers (ex art.36 DPR 633/72",
+				i18n.IT: "Cessione di beni ammortizzabili e per passaggi interni - art.36 DPR 633/72",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD26",
+			}),
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Tags:  []cbc.Key{tax.TagSelfBilled, TagSanMarinoPaper},
+			Name: i18n.String{
+				i18n.EN: "Purchases from San Marino with VAT (paper invoice)",
+				i18n.IT: "Acquisti da San Marino con IVA (fattura cartacea)",
+			},
+			Ext: tax.ExtensionsOf(cbc.CodeMap{
+				ExtKeyDocumentType: "TD28",
+			}),
+		},
+	},
+}

--- a/addon/sdi.go
+++ b/addon/sdi.go
@@ -1,0 +1,80 @@
+// Package sdi handles the extensions and validation rules in order to use
+// GOBL with the Italian SDI and FatturaPA format.
+package sdi
+
+import (
+	"errors"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+const (
+	// Key identifies the SDI addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "it-sdi"
+
+	// V1 for SDI's FatturaPA versions 1.x
+	V1 cbc.Key = Key + "-v1"
+
+	// KeyFundContribution is the key for the Fund Contribution charge
+	KeyFundContribution cbc.Key = "fund-contribution"
+)
+
+func init() {
+	tax.RegisterAddonDef(newAddon())
+	rules.RegisterWithGuard(
+		Key.String(),
+		rules.GOBL.Add("IT-SDI"),
+		is.InContext(tax.AddonIn(V1)),
+		billInvoiceRules(),
+		billChargeRules(),
+		orgAddressRules(),
+		taxComboRules(),
+		payInstructionsRules(),
+		payAdvanceRules(),
+	)
+	norm.RegisterWithGuard(
+		is.InContext(tax.AddonIn(V1)),
+		norm.For(normalizeInvoice),
+		norm.For(normalizePayInstructions),
+		norm.For(normalizePayRecord),
+		norm.For(normalizeAddress),
+		norm.For(normalizeTaxCombo),
+	)
+}
+
+func newAddon() *tax.AddonDef {
+	return &tax.AddonDef{
+		Key: V1,
+		Name: i18n.String{
+			i18n.EN: "Italy SDI FatturaPA v1.x",
+		},
+		Extensions: extensions,
+		Tags: []*tax.TagSet{
+			invoiceTags,
+		},
+		Inboxes:   inboxes,
+		Scenarios: scenarios,
+	}
+}
+
+// validateLatin1String ensures that the item name only contains characters
+// from Latin and Latin-1 range (ASCII 0-127 and extended Latin-1 128-255).
+func validateLatin1String(val any) error {
+	name, _ := val.(string)
+
+	for _, r := range name {
+		// Check if the character is outside Latin and Latin-1 range
+		// Latin and Latin-1 includes ASCII (0-127) and extended Latin-1 (128-255)
+		if r > 255 {
+			return errors.New("contains characters outside of Latin and Latin-1 range")
+		}
+	}
+	return nil
+}

--- a/addon/tax_combo.go
+++ b/addon/tax_combo.go
@@ -1,0 +1,126 @@
+package sdi
+
+import (
+	"fmt"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/regimes/it"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+func normalizeTaxCombo(tc *tax.Combo) {
+	if tc == nil {
+		return
+	}
+
+	// Note: code mappings take from the following URL, Appendix 5.1, with
+	// adjustments for using the outside-scope key.
+	// https://www.fatturapa.gov.it/export/documenti/Technical-Rules-for-European-Invoicing-v2.5.pdf
+
+	switch tc.Category {
+	case tax.CategoryVAT:
+		if tc.Country != "" && tc.Country != "IT" {
+			if l10n.Union(l10n.EU).HasMember(tc.Country.Code()) {
+				tc.Ext = tc.Ext.
+					Set(ExtKeyExempt, "N7")
+			} else {
+				tc.Ext = tc.Ext.
+					Set(ExtKeyExempt, "N2.1")
+			}
+			return
+		}
+		normalizeTaxComboKey(tc)
+		switch tc.Key {
+		case tax.KeyStandard:
+			tc.Ext = tc.Ext.Delete(ExtKeyExempt)
+		case tax.KeyZero:
+			tc.Ext = tc.Ext.Set(ExtKeyExempt, "N1")
+		case tax.KeyOutsideScope:
+			tc.Ext = tc.Ext.SetOneOf(ExtKeyExempt, "N2.1", "N2.2", "N7")
+		case tax.KeyExport:
+			tc.Ext = tc.Ext.SetOneOf(ExtKeyExempt, "N3.1", "N3.3", "N3.4", "N3.5")
+		case tax.KeyIntraCommunity:
+			tc.Ext = tc.Ext.SetOneOf(ExtKeyExempt, "N3.2", "N3.6")
+		case tax.KeyExempt:
+			tc.Ext = tc.Ext.SetOneOf(ExtKeyExempt, "N4", "N5")
+		case tax.KeyReverseCharge:
+			tc.Ext = tc.Ext.SetOneOf(ExtKeyExempt, "N6.9", "N6.1", "N6.2", "N6.3",
+				"N6.4", "N6.5", "N6.6", "N6.7", "N6.8")
+		}
+	}
+}
+
+func normalizeTaxComboKey(tc *tax.Combo) {
+	if tc.Key != "" && tc.Key != tax.KeyExempt {
+		return
+	}
+	switch tc.Ext.Get(ExtKeyExempt) {
+	case "N1":
+		tc.Percent = &num.PercentageZero
+		tc.Key = tax.KeyZero
+	case "N2.1", "N2.2", "N7":
+		tc.Key = tax.KeyOutsideScope
+	case "N3.1", "N3.3", "N3.4", "N3.5":
+		tc.Key = tax.KeyExport
+	case "N3.2", "N3.6":
+		tc.Key = tax.KeyIntraCommunity
+	case "N4", "N5":
+		tc.Key = tax.KeyExempt
+	case "N6.1", "N6.2", "N6.3",
+		"N6.4", "N6.5", "N6.6",
+		"N6.7", "N6.8", "N6.9":
+		tc.Key = tax.KeyReverseCharge
+	case cbc.CodeEmpty:
+		if tc.Key == cbc.KeyEmpty {
+			// Assume standard
+			tc.Key = tax.KeyStandard
+		}
+	}
+}
+
+func taxComboRules() *rules.Set {
+	return rules.For(new(tax.Combo),
+		// VAT: exempt extension required when no percent
+		rules.When(is.Func("VAT without percent", taxComboIsVATWithoutPercent),
+			rules.Field("ext",
+				rules.Assert("01",
+					fmt.Sprintf("VAT tax combo without percent requires '%s' extension", ExtKeyExempt),
+					tax.ExtensionsRequire(ExtKeyExempt),
+				),
+			),
+		),
+		// Retained taxes require the retained extension
+		rules.When(is.Func("is retained tax", taxComboIsRetained),
+			rules.Field("ext",
+				rules.Assert("02",
+					fmt.Sprintf("retained tax combo requires '%s' extension", ExtKeyRetained),
+					tax.ExtensionsRequire(ExtKeyRetained),
+				),
+			),
+		),
+	)
+}
+
+func taxComboIsVATWithoutPercent(val any) bool {
+	c, ok := val.(*tax.Combo)
+	if !ok || c == nil {
+		return false
+	}
+	return c.Category == tax.CategoryVAT && c.Percent == nil
+}
+
+func taxComboIsRetained(val any) bool {
+	c, ok := val.(*tax.Combo)
+	if !ok || c == nil {
+		return false
+	}
+	switch c.Category {
+	case it.TaxCategoryIRPEF, it.TaxCategoryIRES, it.TaxCategoryINPS, it.TaxCategoryENPAM, it.TaxCategoryENASARCO, it.TaxCategoryCP:
+		return true
+	}
+	return false
+}

--- a/addon/tax_combo_test.go
+++ b/addon/tax_combo_test.go
@@ -1,0 +1,77 @@
+package sdi_test
+
+import (
+	"testing"
+
+	sdi "github.com/invopop/gobl.fatturapa/addon"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeTaxCombo(t *testing.T) {
+	ad := tax.AddonForKey(sdi.V1)
+	t.Run("nil", func(t *testing.T) {
+		var tc *tax.Combo
+		assert.NotPanics(t, func() {
+			norm.Normalize(tc, tax.AddonContext(sdi.V1))
+		})
+	})
+
+	t.Run("B2C EU export", func(t *testing.T) {
+		tc := &tax.Combo{
+			Country:  "ES",
+			Category: tax.CategoryVAT,
+			Key:      tax.KeyStandard,
+			Percent:  num.NewPercentage(21, 3),
+		}
+		norm.Normalize(tc, tax.AddonContext(sdi.V1))
+		assert.Equal(t, cbc.Code("N7"), tc.Ext.Get(sdi.ExtKeyExempt))
+	})
+
+	t.Run("B2C other export", func(t *testing.T) {
+		tc := &tax.Combo{
+			Country:  "GB",
+			Category: tax.CategoryVAT,
+			Key:      tax.KeyStandard,
+			Percent:  num.NewPercentage(20, 3),
+		}
+		norm.Normalize(tc, tax.AddonContext(sdi.V1))
+		assert.Equal(t, cbc.Code("N2.1"), tc.Ext.Get(sdi.ExtKeyExempt))
+	})
+
+	t.Run("check all extensions", func(t *testing.T) {
+		ex := cbc.GetKeyDefinition(sdi.ExtKeyExempt, ad.Extensions)
+		codes := cbc.DefinitionCodes(ex.Values)
+
+		for _, code := range codes {
+			t.Run("with code "+code.String(), func(t *testing.T) {
+				tc := &tax.Combo{
+					Category: tax.CategoryVAT,
+					Ext:      tax.ExtensionsOf(cbc.CodeMap{sdi.ExtKeyExempt: code}),
+				}
+				norm.Normalize(tc, tax.AddonContext(sdi.V1))
+				assert.Equal(t, code, tc.Ext.Get(sdi.ExtKeyExempt), "extension should be set correctly")
+				assert.NotEmpty(t, tc.Key, "key should be set based on extension")
+				if tc.Key == tax.KeyZero {
+					assert.NotNil(t, tc.Percent, "percent should be set for zero key")
+					assert.Equal(t, int64(0), tc.Percent.Value())
+				}
+			})
+		}
+	})
+
+	t.Run("check exempt handling", func(t *testing.T) {
+		tc := &tax.Combo{
+			Category: tax.CategoryVAT,
+			Key:      tax.KeyExempt,
+			Ext:      tax.ExtensionsOf(cbc.CodeMap{sdi.ExtKeyExempt: "N3.2"}),
+		}
+		norm.Normalize(tc, tax.AddonContext(sdi.V1))
+		assert.Equal(t, "N3.2", tc.Ext.Get(sdi.ExtKeyExempt).String())
+		assert.Equal(t, tax.KeyIntraCommunity, tc.Key)
+	})
+
+}

--- a/body.go
+++ b/body.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"

--- a/body_parse.go
+++ b/body_parse.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"

--- a/body_parse_test.go
+++ b/body_parse_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl.fatturapa/test"
-	"github.com/invopop/gobl/addons/it/sdi"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"

--- a/fatturapa.go
+++ b/fatturapa.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/text/transform"
 
 	"github.com/invopop/gobl"
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/xmlctx"

--- a/items.go
+++ b/items.go
@@ -3,7 +3,7 @@ package fatturapa
 import (
 	"strconv"
 
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/tax"

--- a/items_parse.go
+++ b/items_parse.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"

--- a/items_parse_test.go
+++ b/items_parse_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl.fatturapa/test"
-	"github.com/invopop/gobl/addons/it/sdi"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"

--- a/parties.go
+++ b/parties.go
@@ -3,7 +3,7 @@ package fatturapa
 import (
 	"errors"
 
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/it"

--- a/parties_parse.go
+++ b/parties_parse.go
@@ -1,7 +1,7 @@
 package fatturapa
 
 import (
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"

--- a/parties_test.go
+++ b/parties_test.go
@@ -3,8 +3,8 @@ package fatturapa_test
 import (
 	"testing"
 
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl.fatturapa/test"
-	"github.com/invopop/gobl/addons/it/sdi"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"

--- a/payments.go
+++ b/payments.go
@@ -1,7 +1,7 @@
 package fatturapa
 
 import (
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/bill"
 )
 

--- a/payments_parse.go
+++ b/payments_parse.go
@@ -1,7 +1,7 @@
 package fatturapa
 
 import (
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/pay"

--- a/retained_taxes.go
+++ b/retained_taxes.go
@@ -3,7 +3,7 @@ package fatturapa
 import (
 	"fmt"
 
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/regimes/it"

--- a/retained_taxes_parse.go
+++ b/retained_taxes_parse.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"

--- a/retained_taxes_parse_test.go
+++ b/retained_taxes_parse_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl.fatturapa/test"
-	"github.com/invopop/gobl/addons/it/sdi"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"

--- a/transmission.go
+++ b/transmission.go
@@ -2,7 +2,7 @@ package fatturapa
 
 import (
 	"github.com/invopop/gobl"
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"

--- a/transmission_parse.go
+++ b/transmission_parse.go
@@ -1,7 +1,7 @@
 package fatturapa
 
 import (
-	"github.com/invopop/gobl/addons/it/sdi"
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"

--- a/transmission_parse_test.go
+++ b/transmission_parse_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	sdi "github.com/invopop/gobl.fatturapa/addon"
 	"github.com/invopop/gobl.fatturapa/test"
-	"github.com/invopop/gobl/addons/it/sdi"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"


### PR DESCRIPTION
Moves the Italian SDI addon into this repo — out of core's in-tree `addons/it/sdi` — setting the repo up to be renamed `gobl.it.sdi`, so the regime addon and its FatturaPA converter live together.

## Changes

- **Addon moved to `./addon`.** Copied from core's `addons/it/sdi`; the converter's imports now point at the local package. Layout matches `gobl.fr.ctc` (root = converter, `addon/` = addon).
- **Tests** — the addon suite, plus invoice scenario coverage migrated from core.
