### PR TITLE
Rename module path to gobl.it.sdi

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,5 +33,5 @@ changelog:
 release:
   github:
     owner: invopop
-    name: gobl.fatturapa
+    name: gobl.it.sdi
   prerelease: auto

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Convert GOBL documents to and from Italy's FatturaPA format.
 
 Copyright [Invopop Ltd.](https://invopop.com) 2023. Released publicly under the [Apache License Version 2.0](LICENSE). For commercial licenses please contact the [dev team at invopop](mailto:dev@invopop.com). In order to accept contributions to this library we will require transferring copyrights to Invopop Ltd.
 
-[![Lint](https://github.com/invopop/gobl.fatturapa/actions/workflows/lint.yaml/badge.svg)](https://github.com/invopop/gobl.fatturapa/actions/workflows/lint.yaml)
-[![Test Go](https://github.com/invopop/gobl.fatturapa/actions/workflows/test.yaml/badge.svg)](https://github.com/invopop/gobl.fatturapa/actions/workflows/test.yaml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/invopop/gobl.fatturapa)](https://goreportcard.com/report/github.com/invopop/gobl.fatturapa)
-[![GoDoc](https://godoc.org/github.com/invopop/gobl.fatturapa?status.svg)](https://godoc.org/github.com/invopop/gobl.fatturapa)
-![Latest Tag](https://img.shields.io/github/v/tag/invopop/gobl.fatturapa)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/invopop/gobl.fatturapa)
+[![Lint](https://github.com/invopop/gobl.it.sdi/actions/workflows/lint.yaml/badge.svg)](https://github.com/invopop/gobl.it.sdi/actions/workflows/lint.yaml)
+[![Test Go](https://github.com/invopop/gobl.it.sdi/actions/workflows/test.yaml/badge.svg)](https://github.com/invopop/gobl.it.sdi/actions/workflows/test.yaml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/invopop/gobl.it.sdi)](https://goreportcard.com/report/github.com/invopop/gobl.it.sdi)
+[![GoDoc](https://godoc.org/github.com/invopop/gobl.it.sdi?status.svg)](https://godoc.org/github.com/invopop/gobl.it.sdi)
+![Latest Tag](https://img.shields.io/github/v/tag/invopop/gobl.it.sdi)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/invopop/gobl.it.sdi)
 
 ## Introduction
 
@@ -169,10 +169,10 @@ Note that when converting from FatturaPA to GOBL:
 
 ### CLI
 
-The command line interface can be useful for situations when you're using a language other than Golang in your application. Download one of the [pre-compiled `gobl.fatturapa` releases](https://github.com/invopop/gobl.fatturapa/releases) or install with:
+The command line interface can be useful for situations when you're using a language other than Golang in your application. Download one of the [pre-compiled `gobl.fatturapa` releases](https://github.com/invopop/gobl.it.sdi/releases) or install with:
 
 ```bash
-go install github.com/invopop/gobl.fatturapa/cmd/gobl.fatturapa
+go install github.com/invopop/gobl.it.sdi/cmd/gobl.fatturapa
 ```
 
 #### Converting GOBL to FatturaPA

--- a/addon/address_test.go
+++ b/addon/address_test.go
@@ -3,7 +3,7 @@ package sdi_test
 import (
 	"testing"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/norm"

--- a/addon/bill_status_test.go
+++ b/addon/bill_status_test.go
@@ -3,7 +3,7 @@ package sdi_test
 import (
 	"testing"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/norm"

--- a/addon/bill_test.go
+++ b/addon/bill_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"

--- a/addon/extensions_test.go
+++ b/addon/extensions_test.go
@@ -3,7 +3,7 @@ package sdi_test
 import (
 	"testing"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"

--- a/addon/invoice_scenarios_test.go
+++ b/addon/invoice_scenarios_test.go
@@ -3,7 +3,7 @@ package sdi_test
 import (
 	"testing"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"

--- a/addon/pay_test.go
+++ b/addon/pay_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"

--- a/addon/tax_combo_test.go
+++ b/addon/tax_combo_test.go
@@ -3,7 +3,7 @@ package sdi_test
 import (
 	"testing"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/norm"
 	"github.com/invopop/gobl/num"

--- a/address_parse_test.go
+++ b/address_parse_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/invopop/gobl.fatturapa/test"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"

--- a/body.go
+++ b/body.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"

--- a/body_parse.go
+++ b/body_parse.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"

--- a/body_parse_test.go
+++ b/body_parse_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
-	"github.com/invopop/gobl.fatturapa/test"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"

--- a/cmd/gobl.fatturapa/convert.go
+++ b/cmd/gobl.fatturapa/convert.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/invopop/gobl"
-	fatturapa "github.com/invopop/gobl.fatturapa"
+	fatturapa "github.com/invopop/gobl.it.sdi"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/xmldsig"
 	"github.com/spf13/cobra"

--- a/examples_test.go
+++ b/examples_test.go
@@ -10,7 +10,7 @@ import (
 
 	"encoding/xml"
 
-	"github.com/invopop/gobl.fatturapa/test"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/invopop/gobl/bill"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/fatturapa.go
+++ b/fatturapa.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/text/transform"
 
 	"github.com/invopop/gobl"
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/xmlctx"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/invopop/gobl.fatturapa
+module github.com/invopop/gobl.it.sdi
 
 go 1.25.0
 

--- a/items.go
+++ b/items.go
@@ -3,7 +3,7 @@ package fatturapa
 import (
 	"strconv"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/tax"

--- a/items_parse.go
+++ b/items_parse.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"

--- a/items_parse_test.go
+++ b/items_parse_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
-	"github.com/invopop/gobl.fatturapa/test"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"

--- a/items_test.go
+++ b/items_test.go
@@ -3,7 +3,7 @@ package fatturapa_test
 import (
 	"testing"
 
-	"github.com/invopop/gobl.fatturapa/test"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/num"

--- a/parties.go
+++ b/parties.go
@@ -3,7 +3,7 @@ package fatturapa
 import (
 	"errors"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/it"

--- a/parties_parse.go
+++ b/parties_parse.go
@@ -1,7 +1,7 @@
 package fatturapa
 
 import (
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"

--- a/parties_parse_test.go
+++ b/parties_parse_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/invopop/gobl.fatturapa/test"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"

--- a/parties_test.go
+++ b/parties_test.go
@@ -3,8 +3,8 @@ package fatturapa_test
 import (
 	"testing"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
-	"github.com/invopop/gobl.fatturapa/test"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"

--- a/payments.go
+++ b/payments.go
@@ -1,7 +1,7 @@
 package fatturapa
 
 import (
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 )
 

--- a/payments_parse.go
+++ b/payments_parse.go
@@ -1,7 +1,7 @@
 package fatturapa
 
 import (
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/pay"

--- a/payments_parse_test.go
+++ b/payments_parse_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/invopop/gobl.fatturapa/test"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/pay"

--- a/payments_test.go
+++ b/payments_test.go
@@ -3,7 +3,7 @@ package fatturapa_test
 import (
 	"testing"
 
-	"github.com/invopop/gobl.fatturapa/test"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/retained_taxes.go
+++ b/retained_taxes.go
@@ -3,7 +3,7 @@ package fatturapa
 import (
 	"fmt"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/regimes/it"

--- a/retained_taxes_parse.go
+++ b/retained_taxes_parse.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"

--- a/retained_taxes_parse_test.go
+++ b/retained_taxes_parse_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
-	"github.com/invopop/gobl.fatturapa/test"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"

--- a/retained_taxes_test.go
+++ b/retained_taxes_test.go
@@ -3,7 +3,7 @@ package fatturapa_test
 import (
 	"testing"
 
-	"github.com/invopop/gobl.fatturapa/test"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/roundtrip_rounding_test.go
+++ b/roundtrip_rounding_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/invopop/gobl"
-	"github.com/invopop/gobl.fatturapa/test"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/invopop/gobl/bill"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/test/test.go
+++ b/test/test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/invopop/gobl"
-	fatturapa "github.com/invopop/gobl.fatturapa"
+	fatturapa "github.com/invopop/gobl.it.sdi"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/schema"

--- a/transmission.go
+++ b/transmission.go
@@ -2,7 +2,7 @@ package fatturapa
 
 import (
 	"github.com/invopop/gobl"
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"

--- a/transmission_parse.go
+++ b/transmission_parse.go
@@ -1,7 +1,7 @@
 package fatturapa
 
 import (
-	sdi "github.com/invopop/gobl.fatturapa/addon"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"

--- a/transmission_parse_test.go
+++ b/transmission_parse_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	sdi "github.com/invopop/gobl.fatturapa/addon"
-	"github.com/invopop/gobl.fatturapa/test"
+	sdi "github.com/invopop/gobl.it.sdi/addon"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"

--- a/transmission_test.go
+++ b/transmission_test.go
@@ -3,7 +3,7 @@ package fatturapa_test
 import (
 	"testing"
 
-	"github.com/invopop/gobl.fatturapa/test"
+	"github.com/invopop/gobl.it.sdi/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
> **Draft — do not merge yet.** The GitHub repo must be renamed `gobl.fatturapa` → `gobl.it.sdi` *before* this merges. Until then, a `go.mod` declaring `gobl.it.sdi` while the repo is still served at `gobl.fatturapa` would fail consumers' module-path check.

## Context

The Italian SDI addon now lives in this repo, and the repo is being renamed to `gobl.it.sdi`. 

## Changes

- `go.mod` module path → `github.com/invopop/gobl.it.sdi`, with every internal import repointed to match.
- `README.md` badges, links, and the `go install` path.
- `.goreleaser.yml` release target → `gobl.it.sdi`.

The converter keeps its identity: the root package stays `fatturapa` and the CLI binary stays `gobl.fatturapa`, only the module path moves. The install command becomes `go install github.com/invopop/gobl.it.sdi/cmd/gobl.fatturapa`.
