### PR TITLE
Map SDI notifications to document statuses

### DIFF
--- a/addon/bill_status.go
+++ b/addon/bill_status.go
@@ -1,0 +1,47 @@
+package sdi
+
+import (
+	"github.com/invopop/gobl/bill"
+)
+
+// normalizeStatus derives each status line's key and the overall status type
+// from the SDI notification code stamped on the line (it-sdi-notification).
+//
+// MC (Mancata Consegna — failed delivery) is the only code whose status
+// depends on the recipient: for a public administration (it-sdi-format FPA12)
+// delivery may still complete later via an AT, so it is non-terminal
+// (processing); for a business recipient (FPR12) it is terminal
+// (acknowledged).
+func normalizeStatus(st *bill.Status) {
+	if st == nil {
+		return
+	}
+	for _, line := range st.Lines {
+		normalizeStatusLine(st, line)
+	}
+}
+
+func normalizeStatusLine(st *bill.Status, line *bill.StatusLine) {
+	if line == nil {
+		return
+	}
+	switch line.Ext.Get(ExtKeyNotification) {
+	case "RC", "AT":
+		line.Key, st.Type = bill.StatusLineAcknowledged, bill.StatusTypeUpdate
+	case "DT":
+		line.Key, st.Type = bill.StatusLineAccepted, bill.StatusTypeUpdate
+	case "NS":
+		line.Key, st.Type = bill.StatusLineError, bill.StatusTypeUpdate
+	case "MC":
+		st.Type = bill.StatusTypeUpdate
+		if line.Ext.Get(ExtKeyFormat) == "FPA12" {
+			line.Key = bill.StatusLineProcessing
+		} else {
+			line.Key = bill.StatusLineAcknowledged
+		}
+	case "EC01":
+		line.Key, st.Type = bill.StatusLineAccepted, bill.StatusTypeResponse
+	case "EC02":
+		line.Key, st.Type = bill.StatusLineRejected, bill.StatusTypeResponse
+	}
+}

--- a/addon/bill_status_test.go
+++ b/addon/bill_status_test.go
@@ -1,0 +1,46 @@
+package sdi_test
+
+import (
+	"testing"
+
+	sdi "github.com/invopop/gobl.fatturapa/addon"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeStatusFromNotification(t *testing.T) {
+	cases := []struct {
+		name   string
+		code   cbc.Code // it-sdi-notification
+		format cbc.Code // it-sdi-format, only consulted for MC
+		want   cbc.Key  // expected line.Key
+		typ    cbc.Key  // expected Status.Type
+	}{
+		{"RC", "RC", "", bill.StatusLineAcknowledged, bill.StatusTypeUpdate},
+		{"AT", "AT", "", bill.StatusLineAcknowledged, bill.StatusTypeUpdate},
+		{"DT", "DT", "", bill.StatusLineAccepted, bill.StatusTypeUpdate},
+		{"MC B2B", "MC", "FPR12", bill.StatusLineAcknowledged, bill.StatusTypeUpdate},
+		{"MC PA", "MC", "FPA12", bill.StatusLineProcessing, bill.StatusTypeUpdate},
+		{"EC01", "EC01", "", bill.StatusLineAccepted, bill.StatusTypeResponse},
+		{"EC02", "EC02", "", bill.StatusLineRejected, bill.StatusTypeResponse},
+		{"NS", "NS", "", bill.StatusLineError, bill.StatusTypeUpdate},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ext := cbc.CodeMap{sdi.ExtKeyNotification: tc.code}
+			if tc.format != "" {
+				ext[sdi.ExtKeyFormat] = tc.format
+			}
+			st := &bill.Status{
+				Addons: tax.WithAddons(sdi.V1),
+				Lines:  []*bill.StatusLine{{Ext: tax.ExtensionsOf(ext)}},
+			}
+			norm.Normalize(st, tax.AddonContext(sdi.V1))
+			assert.Equal(t, tc.want, st.Lines[0].Key)
+			assert.Equal(t, tc.typ, st.Type)
+		})
+	}
+}

--- a/addon/extensions.go
+++ b/addon/extensions.go
@@ -20,6 +20,11 @@ const (
 
 	ExtKeyLiquidationState cbc.Key = "it-sdi-liquidation-state"
 	ExtKeyShareholderState cbc.Key = "it-sdi-shareholder-state"
+
+	// ExtKeyNotification records an SDI notification outcome on a bill.Status
+	// line: either the code SDI emits for the event (RC/NS/MC/AT/DT) or the
+	// recipient response resolved from a Notifica Esito (EC01/EC02).
+	ExtKeyNotification cbc.Key = "it-sdi-notification"
 )
 
 var extensions = []*cbc.Definition{
@@ -1118,6 +1123,93 @@ var extensions = []*cbc.Definition{
 				Name: i18n.String{
 					i18n.EN: "Multiple shareholders",
 					i18n.IT: "Più soci",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyNotification,
+		Name: i18n.String{
+			i18n.EN: "SDI Notification",
+			i18n.IT: "Notifica SDI",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				Outcome SDI reports for a submitted invoice, recorded on a
+				bill.Status line. RC/NS/MC/AT/DT are the codes SDI emits
+				directly; EC01/EC02 are the recipient responses resolved from a
+				Notifica Esito.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "RC",
+				Name: i18n.String{
+					i18n.EN: "Delivery receipt",
+					i18n.IT: "Ricevuta di Consegna",
+				},
+				Desc: i18n.String{
+					i18n.EN: "Delivered to the recipient's channel.",
+				},
+			},
+			{
+				Code: "NS",
+				Name: i18n.String{
+					i18n.EN: "Rejection notice",
+					i18n.IT: "Notifica di Scarto",
+				},
+				Desc: i18n.String{
+					i18n.EN: "SDI rejected the file at its validation gate.",
+				},
+			},
+			{
+				Code: "MC",
+				Name: i18n.String{
+					i18n.EN: "Failed delivery",
+					i18n.IT: "Mancata Consegna",
+				},
+				Desc: i18n.String{
+					i18n.EN: "SDI accepted the file but could not deliver it; parked in the recipient's cassetto fiscale (tax drawer).",
+				},
+			},
+			{
+				Code: "AT",
+				Name: i18n.String{
+					i18n.EN: "Transmission attestation",
+					i18n.IT: "Attestazione di Trasmissione",
+				},
+				Desc: i18n.String{
+					i18n.EN: "Public-administration recipients only: legal proof of transmission when delivery was impossible.",
+				},
+			},
+			{
+				Code: "DT",
+				Name: i18n.String{
+					i18n.EN: "Deadline expiry",
+					i18n.IT: "Decorrenza Termini",
+				},
+				Desc: i18n.String{
+					i18n.EN: "Public-administration recipients only: accepted by silence after 15 days.",
+				},
+			},
+			{
+				Code: "EC01",
+				Name: i18n.String{
+					i18n.EN: "Acceptance",
+					i18n.IT: "Accettazione",
+				},
+				Desc: i18n.String{
+					i18n.EN: "Recipient (public administration) accepted the invoice.",
+				},
+			},
+			{
+				Code: "EC02",
+				Name: i18n.String{
+					i18n.EN: "Refusal",
+					i18n.IT: "Rifiuto",
+				},
+				Desc: i18n.String{
+					i18n.EN: "Recipient (public administration) rejected the invoice.",
 				},
 			},
 		},

--- a/addon/extensions_test.go
+++ b/addon/extensions_test.go
@@ -1,0 +1,23 @@
+package sdi_test
+
+import (
+	"testing"
+
+	sdi "github.com/invopop/gobl.fatturapa/addon"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotificationExtensionRegistered(t *testing.T) {
+	def := tax.ExtensionForKey(sdi.ExtKeyNotification)
+	require.NotNil(t, def, "it-sdi-notification must be registered")
+
+	got := make([]cbc.Code, 0, len(def.Values))
+	for _, v := range def.Values {
+		got = append(got, v.Code)
+	}
+	assert.ElementsMatch(t,
+		[]cbc.Code{"RC", "NS", "MC", "AT", "DT", "EC01", "EC02"}, got)
+}

--- a/addon/sdi.go
+++ b/addon/sdi.go
@@ -46,6 +46,7 @@ func init() {
 		norm.For(normalizePayRecord),
 		norm.For(normalizeAddress),
 		norm.For(normalizeTaxCombo),
+		norm.For(normalizeStatus),
 	)
 }
 


### PR DESCRIPTION
Adds handling for the notifications SDI returns about a submitted invoice — delivery, rejection, acceptance, and so on — turning them into GOBL document statuses.

## Changes

- **`it-sdi-notification` extension** — a closed set of the outcomes SDI reports (`RC`, `NS`, `MC`, `AT`, `DT`, `EC01`, `EC02`), each glossed with its Italian name and English meaning.
- **Status normalizer** — maps the notification code on a `bill.Status` line to its line key and status type. `MC` (failed delivery) resolves by transmission format: non-terminal for a public administration (still awaiting an `AT`), terminal for a business recipient.

## Divergences from gov-it

This table supersedes gov-it's inline mapping, with two deliberate changes:

- **`AT` (transmission attestation) maps to `error`, not `acknowledged`.** GOBL defines `acknowledged` as the buyer having received a readable invoice message — after an AT the recipient received nothing. The AT also requires action: the invoice remains valid, and the sender must deliver it, together with the attestation, to the public administration outside SDI (e.g. via certified email). Mapping it to `acknowledged` reads as "all done" and invites skipping that step. Unlike `NS`, this error does not call for correcting and resubmitting the invoice.
- **`DT` (deadline expiry) keeps `accepted`, with a factual description.** SDI's technical rules state the notification is not itself an acceptance: it closes the process, after which the invoice can no longer be rejected through SDI — which is why it proceeds as accepted in practice. The extension text now describes that instead of stating "accepted by silence".
