### PR TITLE
Use EL tax country code for Greece in EU country check

### DIFF
--- a/eu.go
+++ b/eu.go
@@ -14,7 +14,7 @@ var euCountries = []l10n.Code{
 	l10n.FI, // Finland
 	l10n.FR, // France
 	l10n.DE, // Germany
-	l10n.GR, // Greece
+	l10n.EL, // Greece
 	l10n.HU, // Hungary
 	l10n.IE, // Ireland
 	l10n.IT, // Italy

--- a/parties_test.go
+++ b/parties_test.go
@@ -83,6 +83,22 @@ func TestPartiesSupplier(t *testing.T) {
 		assert.Equal(t, "0000000", s.Identity.TaxID.Code)
 	})
 
+	t.Run("should keep supplier Tax ID for Greek company (EL tax country code)", func(t *testing.T) {
+		env := test.LoadTestFile("invoice-simple.json", test.PathGOBLFatturaPA)
+		test.ModifyInvoice(env, func(inv *bill.Invoice) {
+			inv.Supplier.TaxID.Code = "925667500"
+			inv.Supplier.TaxID.Country = l10n.EL.Tax()
+		})
+
+		doc, err := test.ConvertFromGOBL(env)
+		require.NoError(t, err)
+
+		s := doc.Header.Supplier
+
+		assert.Equal(t, "EL", s.Identity.TaxID.Country)
+		assert.Equal(t, "925667500", s.Identity.TaxID.Code)
+	})
+
 	t.Run("should replace supplier ID info for non-EU company with Tax ID given", func(t *testing.T) {
 		env := test.LoadTestFile("invoice-simple.json", test.PathGOBLFatturaPA)
 		test.ModifyInvoice(env, func(inv *bill.Invoice) {


### PR DESCRIPTION
Fix the EU membership check to match Greece by its tax country code `EL` instead of the ISO code `GR`. Greek parties with a VAT number were treated as non-EU and their code replaced with the `OO99999999999` placeholder.

Changes:
- Replace `l10n.GR` with `l10n.EL` in the `euCountries` list
- Add regression test for a Greek (EL) supplier keeping its VAT code

🤖 Generated with [Claude Code](https://claude.com/claude-code)