### PR TITLE
Ignore customer PEC inbox when codice destinatario is present

### DIFF
--- a/test/data/gobl.fatturapa/invoice-simple-with-code-and-pec.json
+++ b/test/data/gobl.fatturapa/invoice-simple-with-code-and-pec.json
@@ -1,0 +1,225 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "679a2f25-7483-11ec-9722-7ea2cb436ff6",
+		"dig": {
+			"alg": "sha256",
+			"val": "c59929fa980d6fd91bb832cfa869e0df0e792550ba04636bd325e00070084ab9"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "IT",
+		"$addons": [
+			"it-sdi-v1"
+		],
+		"$tags": [
+			"freelance"
+		],
+		"uuid": "0190caea-c35f-72c1-92a0-728defa74ce2",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2023-03-02",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"it-sdi-document-type": "TD06",
+				"it-sdi-format": "FPR12"
+			}
+		},
+		"supplier": {
+			"name": "MªF. Services",
+			"tax_id": {
+				"country": "IT",
+				"code": "12345678903"
+			},
+			"people": [
+				{
+					"name": {
+						"given": "GIANCARLO",
+						"surname": "ROSSI"
+					}
+				}
+			],
+			"addresses": [
+				{
+					"num": "1",
+					"street": "VIALE DELLA LIBERTÀ",
+					"locality": "ROMA",
+					"region": "RM",
+					"code": "00100",
+					"country": "IT"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			],
+			"telephones": [
+				{
+					"num": "999999999"
+				}
+			],
+			"registration": {
+				"capital": "50000.00",
+				"currency": "EUR",
+				"office": "RM",
+				"entry": "123456"
+			},
+			"ext": {
+				"it-sdi-fiscal-regime": "RF01"
+			}
+		},
+		"customer": {
+			"name": "MARIO LEONI",
+			"tax_id": {
+				"country": "IT",
+				"code": "09876543217"
+			},
+			"people": [
+				{
+					"name": {
+						"prefix": "Dott.",
+						"given": "MARIO",
+						"surname": "LEONI"
+					}
+				}
+			],
+			"inboxes": [
+				{
+					"key": "it-sdi-pec",
+					"email": "fooo@inbox.com"
+				},
+				{
+					"key": "it-sdi-code",
+					"code": "ABC1234"
+				}
+			],
+			"addresses": [
+				{
+					"num": "32",
+					"street": "VIALE DELI LAVORATORI",
+					"locality": "FIRENZE",
+					"region": "FI",
+					"code": "50100",
+					"country": "IT"
+				}
+			],
+			"emails": [
+				{
+					"addr": "leoni@mario.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"reason": "Special discount",
+						"percent": "10%",
+						"amount": "180.00"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "22.0%"
+					}
+				],
+				"total": "1620.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Special Untaxed Work",
+					"price": "100.00",
+					"unit": "h"
+				},
+				"sum": "100.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "outside-scope",
+						"ext": {
+							"it-sdi-exempt": "N2.2"
+						}
+					}
+				],
+				"total": "100.00"
+			}
+		],
+		"discounts": [
+			{
+				"i": 1,
+				"reason": "10th year anniversary discount",
+				"base": "1720.00",
+				"percent": "50%",
+				"amount": "860.00"
+			}
+		],
+		"charges": [
+			{
+				"i": 1,
+				"reason": "10th year anniversary charge",
+				"base": "1720.00",
+				"percent": "10%",
+				"amount": "172.00"
+			}
+		],
+		"payment": {
+			"instructions": {
+				"key": "card",
+				"ext": {
+					"it-sdi-payment-means": "MP08"
+				}
+			}
+		},
+		"totals": {
+			"sum": "1720.00",
+			"discount": "860.00",
+			"charge": "172.00",
+			"total": "1032.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1620.00",
+								"percent": "22.0%",
+								"amount": "356.40"
+							},
+							{
+								"key": "outside-scope",
+								"ext": {
+									"it-sdi-exempt": "N2.2"
+								},
+								"base": "100.00",
+								"amount": "0.00"
+							}
+						],
+						"amount": "356.40"
+					}
+				],
+				"sum": "356.40"
+			},
+			"tax": "356.40",
+			"total_with_tax": "1388.40",
+			"payable": "1388.40"
+		}
+	}
+}

--- a/test/data/gobl.fatturapa/out/invoice-simple-with-code-and-pec.xml
+++ b/test/data/gobl.fatturapa/out/invoice-simple-with-code-and-pec.xml
@@ -1,0 +1,193 @@
+<p:FatturaElettronica xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" versione="FPR12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 https://www.fatturapa.gov.it/export/documenti/fatturapa/v1.2.2/Schema_del_file_xml_FatturaPA_v1.2.2.xsd">
+	<FatturaElettronicaHeader>
+		<DatiTrasmissione>
+			<IdTrasmittente>
+				<IdPaese>IT</IdPaese>
+				<IdCodice>01234567890</IdCodice>
+			</IdTrasmittente>
+			<ProgressivoInvio>679a2f25</ProgressivoInvio>
+			<FormatoTrasmissione>FPR12</FormatoTrasmissione>
+			<CodiceDestinatario>ABC1234</CodiceDestinatario>
+		</DatiTrasmissione>
+		<CedentePrestatore>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>12345678903</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>MªF. Services</Denominazione>
+				</Anagrafica>
+				<RegimeFiscale>RF01</RegimeFiscale>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>VIALE DELLA LIBERTÀ</Indirizzo>
+				<NumeroCivico>1</NumeroCivico>
+				<CAP>00100</CAP>
+				<Comune>ROMA</Comune>
+				<Provincia>RM</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+			<IscrizioneREA>
+				<Ufficio>RM</Ufficio>
+				<NumeroREA>123456</NumeroREA>
+				<CapitaleSociale>50000.00</CapitaleSociale>
+				<StatoLiquidazione>LN</StatoLiquidazione>
+			</IscrizioneREA>
+			<Contatti>
+				<Telefono>999999999</Telefono>
+				<Email>billing@example.com</Email>
+			</Contatti>
+		</CedentePrestatore>
+		<CessionarioCommittente>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>09876543217</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>MARIO LEONI</Denominazione>
+				</Anagrafica>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>VIALE DELI LAVORATORI</Indirizzo>
+				<NumeroCivico>32</NumeroCivico>
+				<CAP>50100</CAP>
+				<Comune>FIRENZE</Comune>
+				<Provincia>FI</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+		</CessionarioCommittente>
+	</FatturaElettronicaHeader>
+	<FatturaElettronicaBody>
+		<DatiGenerali>
+			<DatiGeneraliDocumento>
+				<TipoDocumento>TD06</TipoDocumento>
+				<Divisa>EUR</Divisa>
+				<Data>2023-03-02</Data>
+				<Numero>SAMPLE-001</Numero>
+				<ScontoMaggiorazione>
+					<Tipo>SC</Tipo>
+					<Percentuale>50.00</Percentuale>
+					<Importo>860.00</Importo>
+				</ScontoMaggiorazione>
+				<ScontoMaggiorazione>
+					<Tipo>MG</Tipo>
+					<Percentuale>10.00</Percentuale>
+					<Importo>172.00</Importo>
+				</ScontoMaggiorazione>
+				<ImportoTotaleDocumento>1388.40</ImportoTotaleDocumento>
+			</DatiGeneraliDocumento>
+		</DatiGenerali>
+		<DatiBeniServizi>
+			<DettaglioLinee>
+				<NumeroLinea>1</NumeroLinea>
+				<Descrizione>Development services</Descrizione>
+				<Quantita>20.00</Quantita>
+				<UnitaMisura>h</UnitaMisura>
+				<PrezzoUnitario>90.00</PrezzoUnitario>
+				<ScontoMaggiorazione>
+					<Tipo>SC</Tipo>
+					<Percentuale>10.00</Percentuale>
+					<Importo>9.0000</Importo>
+				</ScontoMaggiorazione>
+				<PrezzoTotale>1620.00</PrezzoTotale>
+				<AliquotaIVA>22.00</AliquotaIVA>
+			</DettaglioLinee>
+			<DettaglioLinee>
+				<NumeroLinea>2</NumeroLinea>
+				<Descrizione>Special Untaxed Work</Descrizione>
+				<Quantita>1.00</Quantita>
+				<UnitaMisura>h</UnitaMisura>
+				<PrezzoUnitario>100.00</PrezzoUnitario>
+				<PrezzoTotale>100.00</PrezzoTotale>
+				<AliquotaIVA>0.00</AliquotaIVA>
+				<Natura>N2.2</Natura>
+			</DettaglioLinee>
+			<DatiRiepilogo>
+				<AliquotaIVA>22.00</AliquotaIVA>
+				<ImponibileImporto>1620.00</ImponibileImporto>
+				<Imposta>356.40</Imposta>
+			</DatiRiepilogo>
+			<DatiRiepilogo>
+				<AliquotaIVA>0.00</AliquotaIVA>
+				<Natura>N2.2</Natura>
+				<ImponibileImporto>100.00</ImponibileImporto>
+				<Imposta>0.00</Imposta>
+				<RiferimentoNormativo>Non soggette - altri casi</RiferimentoNormativo>
+			</DatiRiepilogo>
+		</DatiBeniServizi>
+		<DatiPagamento>
+			<CondizioniPagamento>TP02</CondizioniPagamento>
+			<DettaglioPagamento>
+				<ModalitaPagamento>MP08</ModalitaPagamento>
+				<ImportoPagamento>1388.40</ImportoPagamento>
+			</DettaglioPagamento>
+		</DatiPagamento>
+	</FatturaElettronicaBody>
+	<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-Signature">
+		<ds:SignedInfo>
+			<ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"></ds:CanonicalizationMethod>
+			<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"></ds:SignatureMethod>
+			<ds:Reference Id="Reference-679a2f25-7483-11ec-9722-7ea2cb436ff6" Type="http://www.w3.org/2000/09/xmldsig#Object" URI="">
+				<ds:Transforms>
+					<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>
+				</ds:Transforms>
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>FRvxxVFumjRpx+nr18x3zlhNFySohL9AdwmD7nm6KpfUIV5hxWn+TA3mPEeHL5k3YSqkw7tiRLgwupYJAuqB4Q==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference URI="#Certificate-679a2f25-7483-11ec-9722-7ea2cb436ff6">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>6+b9KJiVX/kpy7+O7yI2sGdhrxIlXzoDNTq47UDlH9Pkx7IKuEmt6cmyCYAvblLsWfllzb0LQVhi5TGvh3wWLw==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-SignedProperties">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>7Tj/Vr2iDe5KuUvZfrT8ntgjkAtz6zIeztpC/liVkbigGbZLGFHcMpSsVtsRc+WIqqwsB7AwFVjqjSIKIDI3uw==</ds:DigestValue>
+			</ds:Reference>
+		</ds:SignedInfo>
+		<ds:SignatureValue Id="Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-SignatureValue">qCMWyDZKe8TsKpPJOLQykhmEsa2XqkZNUL9VNKy4zP37LeDyA+eZzW8PSdv4UE8LSOgtFYnhXuFzML6Vbm7IJDnfnkXskDagAG7kmYC1NzHN0Cydy8pgMYnHmg5yE9pkXM3ujpCfFy3st8IvJZFq56+qtpx4g9UhKMxaW4C+CbPz6af2ufSQ3GAPbiGKRIYvmvaKFeGBjg4cvL/XyFQIdlntFqJe1XfO10lJy5I3vM761lY5s2WFJC4BkedB8Y8JP4HgSeXFOshdwjAxqrCYrdhoCD8vuimqhydjm090lI88MaQHDg3VNGnh1PAepQLwcZr2OCviand3MPLSm0S+1A==</ds:SignatureValue>
+		<ds:KeyInfo Id="Certificate-679a2f25-7483-11ec-9722-7ea2cb436ff6">
+			<ds:X509Data>
+				<ds:X509Certificate>MIIHhjCCBm6gAwIBAgIQSOSlyjvRFUlfo/hUFNAvqDANBgkqhkiG9w0BAQsFADBLMQswCQYDVQQGEwJFUzERMA8GA1UECgwIRk5NVC1SQ00xDjAMBgNVBAsMBUNlcmVzMRkwFwYDVQQDDBBBQyBGTk1UIFVzdWFyaW9zMB4XDTIwMTEwNTEzMDQyMFoXDTI0MTEwNTEzMDQyMFowgYUxCzAJBgNVBAYTAkVTMRgwFgYDVQQFEw9JRENFUy05OTk5OTk5OVIxEDAOBgNVBCoMB1BSVUVCQVMxGjAYBgNVBAQMEUVJREFTIENFUlRJRklDQURPMS4wLAYDVQQDDCVFSURBUyBDRVJUSUZJQ0FETyBQUlVFQkFTIC0gOTk5OTk5OTlSMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQIDAQABo4IEKTCCBCUwgZIGA1UdEQSBijCBh4Edc29wb3J0ZV90ZWNuaWNvX2NlcmVzQGZubXQuZXOkZjBkMRgwFgYJKwYBBAGsZgEEDAk5OTk5OTk5OVIxGjAYBgkrBgEEAaxmAQMMC0NFUlRJRklDQURPMRQwEgYJKwYBBAGsZgECDAVFSURBUzEWMBQGCSsGAQQBrGYBAQwHUFJVRUJBUzAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIF4DAdBgNVHSUEFjAUBggrBgEFBQcDBAYIKwYBBQUHAwIwHQYDVR0OBBYEFE5aHiQQRwVYJzmmkfG/i5MxmMNdMB8GA1UdIwQYMBaAFLHUT8QjefpEBQnG6znP6DWwuCBkMIGCBggrBgEFBQcBAQR2MHQwPQYIKwYBBQUHMAGGMWh0dHA6Ly9vY3NwdXN1LmNlcnQuZm5tdC5lcy9vY3NwdXN1L09jc3BSZXNwb25kZXIwMwYIKwYBBQUHMAKGJ2h0dHA6Ly93d3cuY2VydC5mbm10LmVzL2NlcnRzL0FDVVNVLmNydDCCARUGA1UdIASCAQwwggEIMIH6BgorBgEEAaxmAwoBMIHrMCkGCCsGAQUFBwIBFh1odHRwOi8vd3d3LmNlcnQuZm5tdC5lcy9kcGNzLzCBvQYIKwYBBQUHAgIwgbAMga1DZXJ0aWZpY2FkbyBjdWFsaWZpY2FkbyBkZSBmaXJtYSBlbGVjdHLDs25pY2EuIFN1amV0byBhIGxhcyBjb25kaWNpb25lcyBkZSB1c28gZXhwdWVzdGFzIGVuIGxhIERQQyBkZSBsYSBGTk1ULVJDTSBjb24gTklGOiBRMjgyNjAwNC1KIChDL0pvcmdlIEp1YW4gMTA2LTI4MDA5LU1hZHJpZC1Fc3Bhw7FhKTAJBgcEAIvsQAEAMIG6BggrBgEFBQcBAwSBrTCBqjAIBgYEAI5GAQEwCwYGBACORgEDAgEPMBMGBgQAjkYBBjAJBgcEAI5GAQYBMHwGBgQAjkYBBTByMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lcy5wZGYTAmVzMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lbi5wZGYTAmVuMIG1BgNVHR8Ega0wgaowgaeggaSggaGGgZ5sZGFwOi8vbGRhcHVzdS5jZXJ0LmZubXQuZXMvY249Q1JMMzc0OCxjbj1BQyUyMEZOTVQlMjBVc3VhcmlvcyxvdT1DRVJFUyxvPUZOTVQtUkNNLGM9RVM/Y2VydGlmaWNhdGVSZXZvY2F0aW9uTGlzdDtiaW5hcnk/YmFzZT9vYmplY3RjbGFzcz1jUkxEaXN0cmlidXRpb25Qb2ludDANBgkqhkiG9w0BAQsFAAOCAQEAH4t5/v/SLsm/dXRDw4QblCmTX+5pgXJ+4G1Lb3KTSPtDJ0UbQiAMUx+iqDDOoMHU5H7po/HZLJXgNwvKLoiLbl5/q6Mqasif87fa6awNkuz/Y6dvXw0UOJh+Ud/Wrk0EyaP9ZtrLVsraUOobNyS6g+lOrCxRrNxGRK2yAeotO6LEo1y3b7CB+Amd2jDq8lY3AtCYlrhuCaTf0AD9IBYYmigHzFD/VH5a8uG95l6J85FQG7tMsG6UQHFM2EmNhpbrYH+ihetz3UhzcC5Fd/P1X7pGBymQgbCyBjCRf/HEVzyoHL72uMp2I4JXX4v8HABZT8xtlDY4LE0am9keJhaNcg==</ds:X509Certificate>
+			</ds:X509Data>
+			<ds:KeyValue>
+				<ds:RSAKeyValue>
+					<ds:Modulus>ujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQ==</ds:Modulus>
+					<ds:Exponent>AQAB</ds:Exponent>
+				</ds:RSAKeyValue>
+			</ds:KeyValue>
+		</ds:KeyInfo>
+		<ds:Object>
+			<xades:QualifyingProperties xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" Id="Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-QualifyingProperties" Target="#Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-Signature">
+				<xades:SignedProperties Id="Signature-679a2f25-7483-11ec-9722-7ea2cb436ff6-SignedProperties">
+					<xades:SignedSignatureProperties>
+						<xades:SigningTime>2022-02-01T04:00:00+00:00</xades:SigningTime>
+						<xades:SigningCertificate>
+							<xades:Cert>
+								<xades:CertDigest>
+									<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+									<ds:DigestValue>VmNYwDiCBBXJX/IL1AUYj7uHouM2Jcp3ZkeqmB+FKGTTwXIIZnCWmZVhCSB7uNoV6Xee7nZVkMqeCMQk3tGR0g==</ds:DigestValue>
+								</xades:CertDigest>
+								<xades:IssuerSerial>
+									<ds:X509IssuerName>CN=AC FNMT Usuarios,OU=Ceres,O=FNMT-RCM,C=ES</ds:X509IssuerName>
+									<ds:X509SerialNumber>96891622000445695554354105786026700712</ds:X509SerialNumber>
+								</xades:IssuerSerial>
+							</xades:Cert>
+						</xades:SigningCertificate>
+					</xades:SignedSignatureProperties>
+					<xades:SignedDataObjectProperties>
+						<xades:DataObjectFormat ObjectReference="#Reference-679a2f25-7483-11ec-9722-7ea2cb436ff6">
+							<xades:Description>Fattura PA</xades:Description>
+							<xades:ObjectIdentifier>
+								<xades:Identifier Qualifier="OIDAsURN">urn:oid:1.2.840.10003.5.109.10</xades:Identifier>
+								<xades:Description></xades:Description>
+							</xades:ObjectIdentifier>
+							<xades:MimeType>text/xml</xades:MimeType>
+							<xades:Encoding></xades:Encoding>
+						</xades:DataObjectFormat>
+					</xades:SignedDataObjectProperties>
+				</xades:SignedProperties>
+			</xades:QualifyingProperties>
+		</ds:Object>
+	</ds:Signature>
+</p:FatturaElettronica>

--- a/transmission.go
+++ b/transmission.go
@@ -77,6 +77,13 @@ func codiceDestinatario(cus *org.Party) string {
 func pecDestinatario(cus *org.Party) string {
 	if cus != nil {
 		for _, inbox := range cus.Inboxes {
+			// PECDestinatario is only allowed alongside the "0000000" code,
+			// so a codice destinatario inbox takes precedence over the PEC.
+			if inbox.Key == sdi.KeyInboxCode {
+				return ""
+			}
+		}
+		for _, inbox := range cus.Inboxes {
 			if inbox.Key == sdi.KeyInboxPEC {
 				if inbox.Email != "" {
 					return inbox.Email

--- a/transmission_test.go
+++ b/transmission_test.go
@@ -50,4 +50,16 @@ func TestTransmissionData(t *testing.T) {
 		assert.Equal(t, "0000000", dt.RecipientCode)
 		assert.Equal(t, "fooo@inbox.com", dt.RecipientPEC)
 	})
+
+	t.Run("should ignore the PEC when the customer also has a codice destinatario", func(t *testing.T) {
+
+		env := test.LoadTestFile("invoice-simple-with-code-and-pec.json", test.PathGOBLFatturaPA)
+		doc, err := test.ConvertFromGOBL(env, test.LoadOptions()...)
+		require.NoError(t, err)
+
+		dt := doc.Header.TransmissionData
+
+		assert.Equal(t, "ABC1234", dt.RecipientCode)
+		assert.Equal(t, "", dt.RecipientPEC)
+	})
 }


### PR DESCRIPTION
## Context

FatturaPA's `DatiTrasmissione` block allows a single routing destination: per the specification, `PECDestinatario` may only be populated when `CodiceDestinatario` is the placeholder `0000000`. A GOBL customer can legitimately carry both an `it-sdi-code` and an `it-sdi-pec` inbox, but until now the converter wrote both fields, producing XML that is never valid for delivery.

Resolving this at conversion time (rather than validating or normalizing the GOBL document) means already-signed documents carrying both inboxes become deliverable as-is.

## Changes

- When the customer has a codice destinatario inbox, the PEC inbox is ignored: `CodiceDestinatario` carries the code and `PECDestinatario` is omitted. The code wins because a PEC destination is only meaningful without one.
- New fixture `invoice-simple-with-code-and-pec.json` with its golden XML covering the scenario (forward-only)