### PR TITLE
Read TipoRitenuta codes from the tax category map

### DIFF
--- a/retained_taxes.go
+++ b/retained_taxes.go
@@ -10,6 +10,10 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+// itRegime provides the category definitions that map retained taxes to their
+// TipoRitenuta codes.
+var itRegime = tax.RegimeDefFor(it.CountryCode)
+
 // RetainedTax represents a retained tax.
 type RetainedTax struct {
 	Type   string `xml:"TipoRitenuta"`
@@ -75,18 +79,10 @@ func retainedExtensionCode(ext tax.Extensions) string {
 }
 
 func findCodeTaxType(cat cbc.Code) (string, error) {
-	switch cat {
-	case it.TaxCategoryIRPEF:
-		return "RT01", nil
-	case it.TaxCategoryIRES:
-		return "RT02", nil
-	case it.TaxCategoryINPS:
-		return "RT03", nil
-	case it.TaxCategoryENASARCO:
-		return "RT04", nil
-	case it.TaxCategoryENPAM:
-		return "RT05", nil
-	default:
-		return "", fmt.Errorf("could not find TipoRitenuta code for tax category %s", cat)
+	if def := itRegime.CategoryDef(cat); def != nil {
+		if code := def.Map[it.KeyFatturaPATipoRitenuta]; code != cbc.CodeEmpty {
+			return code.String(), nil
+		}
 	}
+	return "", fmt.Errorf("could not find TipoRitenuta code for tax category %s", cat)
 }

--- a/retained_taxes_internal_test.go
+++ b/retained_taxes_internal_test.go
@@ -1,0 +1,91 @@
+package fatturapa
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/regimes/it"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindCodeTaxType(t *testing.T) {
+	tests := []struct {
+		cat  cbc.Code
+		want string
+	}{
+		{it.TaxCategoryIRPEF, "RT01"},
+		{it.TaxCategoryIRES, "RT02"},
+		{it.TaxCategoryINPS, "RT03"},
+		{it.TaxCategoryENASARCO, "RT04"},
+		{it.TaxCategoryENPAM, "RT05"},
+		{it.TaxCategoryCP, "RT06"},
+	}
+	for _, test := range tests {
+		t.Run(test.cat.String(), func(t *testing.T) {
+			code, err := findCodeTaxType(test.cat)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, code)
+		})
+	}
+
+	t.Run("category without a mapping", func(t *testing.T) {
+		_, err := findCodeTaxType(tax.CategoryVAT)
+		assert.ErrorContains(t, err, "could not find TipoRitenuta code for tax category VAT")
+	})
+
+	t.Run("unknown category", func(t *testing.T) {
+		_, err := findCodeTaxType("FOO")
+		assert.ErrorContains(t, err, "could not find TipoRitenuta code for tax category FOO")
+	})
+}
+
+func TestConvertRetainedTaxType(t *testing.T) {
+	tests := []struct {
+		code string
+		want cbc.Code
+	}{
+		{"RT01", it.TaxCategoryIRPEF},
+		{"RT02", it.TaxCategoryIRES},
+		{"RT03", it.TaxCategoryINPS},
+		{"RT04", it.TaxCategoryENASARCO},
+		{"RT05", it.TaxCategoryENPAM},
+		{"RT06", it.TaxCategoryCP},
+	}
+	for _, test := range tests {
+		t.Run(test.code, func(t *testing.T) {
+			cat, err := convertRetainedTaxType(test.code)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, cat)
+		})
+	}
+
+	t.Run("unknown code", func(t *testing.T) {
+		_, err := convertRetainedTaxType("RT99")
+		assert.ErrorContains(t, err, "unknown TipoRitenuta code: RT99")
+	})
+
+	t.Run("empty code", func(t *testing.T) {
+		_, err := convertRetainedTaxType("")
+		assert.ErrorContains(t, err, "unknown TipoRitenuta code")
+	})
+}
+
+// Every retained category must map to a TipoRitenuta code, and each code back
+// to the category it came from.
+func TestRetainedTaxTypesRoundTrip(t *testing.T) {
+	for _, def := range itRegime.Categories {
+		if !def.Retained {
+			continue
+		}
+		t.Run(def.Code.String(), func(t *testing.T) {
+			code, err := findCodeTaxType(def.Code)
+			require.NoError(t, err)
+
+			cat, err := convertRetainedTaxType(code)
+			require.NoError(t, err)
+			assert.Equal(t, def.Code, cat, "%s is mapped by more than one category", code)
+		})
+	}
+}

--- a/retained_taxes_parse.go
+++ b/retained_taxes_parse.go
@@ -150,18 +150,12 @@ func copyExtensions(ext tax.Extensions) tax.Extensions {
 
 // convertRetainedTaxType converts a TipoRitenuta code to a tax category code
 func convertRetainedTaxType(tipoRitenuta string) (cbc.Code, error) {
-	switch tipoRitenuta {
-	case "RT01":
-		return it.TaxCategoryIRPEF, nil
-	case "RT02":
-		return it.TaxCategoryIRES, nil
-	case "RT03":
-		return it.TaxCategoryINPS, nil
-	case "RT04":
-		return it.TaxCategoryENASARCO, nil
-	case "RT05":
-		return it.TaxCategoryENPAM, nil
-	default:
-		return "", fmt.Errorf("unknown TipoRitenuta code: %s", tipoRitenuta)
+	if code := cbc.Code(tipoRitenuta); code != cbc.CodeEmpty {
+		for _, def := range itRegime.Categories {
+			if def.Map[it.KeyFatturaPATipoRitenuta] == code {
+				return def.Code, nil
+			}
+		}
 	}
+	return "", fmt.Errorf("unknown TipoRitenuta code: %s", tipoRitenuta)
 }

--- a/test/data/fatturapa.gobl/invoice-retained-cp.xml
+++ b/test/data/fatturapa.gobl/invoice-retained-cp.xml
@@ -1,0 +1,165 @@
+<p:FatturaElettronica xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" versione="FPR12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 https://www.fatturapa.gov.it/export/documenti/fatturapa/v1.2.2/Schema_del_file_xml_FatturaPA_v1.2.2.xsd">
+	<FatturaElettronicaHeader>
+		<DatiTrasmissione>
+			<IdTrasmittente>
+				<IdPaese>IT</IdPaese>
+				<IdCodice>01234567890</IdCodice>
+			</IdTrasmittente>
+			<ProgressivoInvio>019ffa77</ProgressivoInvio>
+			<FormatoTrasmissione>FPR12</FormatoTrasmissione>
+			<CodiceDestinatario>ABCDEF1</CodiceDestinatario>
+		</DatiTrasmissione>
+		<CedentePrestatore>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>12345678903</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>Studio Bianchi</Denominazione>
+				</Anagrafica>
+				<RegimeFiscale>RF01</RegimeFiscale>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>VIALE DELLA LIBERTÀ</Indirizzo>
+				<NumeroCivico>1</NumeroCivico>
+				<CAP>00100</CAP>
+				<Comune>ROMA</Comune>
+				<Provincia>RM</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+			<Contatti></Contatti>
+		</CedentePrestatore>
+		<CessionarioCommittente>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>13029381004</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>Impresa Verdi SRL</Denominazione>
+				</Anagrafica>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>VIALE DELI LAVORATORI</Indirizzo>
+				<NumeroCivico>32</NumeroCivico>
+				<CAP>50100</CAP>
+				<Comune>FIRENZE</Comune>
+				<Provincia>FI</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+		</CessionarioCommittente>
+	</FatturaElettronicaHeader>
+	<FatturaElettronicaBody>
+		<DatiGenerali>
+			<DatiGeneraliDocumento>
+				<TipoDocumento>TD06</TipoDocumento>
+				<Divisa>EUR</Divisa>
+				<Data>2023-03-02</Data>
+				<Numero>SAMPLE-004</Numero>
+				<DatiRitenuta>
+					<TipoRitenuta>RT01</TipoRitenuta>
+					<ImportoRitenuta>200.00</ImportoRitenuta>
+					<AliquotaRitenuta>20.00</AliquotaRitenuta>
+					<CausalePagamento>A</CausalePagamento>
+				</DatiRitenuta>
+				<DatiRitenuta>
+					<TipoRitenuta>RT06</TipoRitenuta>
+					<ImportoRitenuta>40.00</ImportoRitenuta>
+					<AliquotaRitenuta>4.00</AliquotaRitenuta>
+					<CausalePagamento>A</CausalePagamento>
+				</DatiRitenuta>
+				<ImportoTotaleDocumento>980.00</ImportoTotaleDocumento>
+			</DatiGeneraliDocumento>
+		</DatiGenerali>
+		<DatiBeniServizi>
+			<DettaglioLinee>
+				<NumeroLinea>1</NumeroLinea>
+				<Descrizione>Consulenza tecnica</Descrizione>
+				<Quantita>1.00</Quantita>
+				<PrezzoUnitario>1000.00</PrezzoUnitario>
+				<PrezzoTotale>1000.00</PrezzoTotale>
+				<AliquotaIVA>22.00</AliquotaIVA>
+				<Ritenuta>SI</Ritenuta>
+			</DettaglioLinee>
+			<DatiRiepilogo>
+				<AliquotaIVA>22.00</AliquotaIVA>
+				<ImponibileImporto>1000.00</ImponibileImporto>
+				<Imposta>220.00</Imposta>
+			</DatiRiepilogo>
+		</DatiBeniServizi>
+		<DatiPagamento>
+			<CondizioniPagamento>TP02</CondizioniPagamento>
+			<DettaglioPagamento>
+				<ModalitaPagamento>MP05</ModalitaPagamento>
+				<ImportoPagamento>980.00</ImportoPagamento>
+				<IBAN>IT60X0542811101000000123456</IBAN>
+			</DettaglioPagamento>
+		</DatiPagamento>
+	</FatturaElettronicaBody>
+	<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="Signature-019ffa77-c5c7-72af-b549-db41f0c8100c-Signature">
+		<ds:SignedInfo>
+			<ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"></ds:CanonicalizationMethod>
+			<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"></ds:SignatureMethod>
+			<ds:Reference Id="Reference-019ffa77-c5c7-72af-b549-db41f0c8100c" Type="http://www.w3.org/2000/09/xmldsig#Object" URI="">
+				<ds:Transforms>
+					<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>
+				</ds:Transforms>
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>KaEuaRu6EYhT72f2u0Bty/dqctCB5xDndgqM8QB4dfIJ0qmEPF5vCsai4Lh8eCUa64WbYdYkKc7ktlb3w5OPvw==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference URI="#Certificate-019ffa77-c5c7-72af-b549-db41f0c8100c">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>cmJnBKVOkY8yXTRrlo6srtKjAsr7v+1iZYCDiTvokgG1fXbyeE2YHAkXlbLwh66TeI38Sn17hkQh0oZnlr+1wA==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#Signature-019ffa77-c5c7-72af-b549-db41f0c8100c-SignedProperties">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>977fydVn77nr8hWQXRr+UAd3dju6WL3mm2kU44m4VRi8nQAypBCkQn7PxiZZH1wGkEGo0qrDPsxOP4P2AXv1EQ==</ds:DigestValue>
+			</ds:Reference>
+		</ds:SignedInfo>
+		<ds:SignatureValue Id="Signature-019ffa77-c5c7-72af-b549-db41f0c8100c-SignatureValue">b0IDwyAFGvpMB2+5+rPTvR4NoBryesQlXakQuaOxcwpa4YX8uwGPXAeigu7w2q9FslRa4RIoXESc90oxPR8T7Je2cNxKq7QeKdXXEu+tvFWD1kdRvEFiG+HsD43ivPvvalFykMJU8VzrPPTZxOUpQKif460I6tAMvFdcIHkGAOa5RkWG9y6pAaEdu+loJQ2FX0CDLl1wokhdUMuGXDA/z+SyuUrNa1zNhEqLEYRGYYrAboUYrtSjbcAMtrQX+eqIDk6yrcMVX+wuia327q+PMpE0KrXDqp3G0mY6fp6bf8UgraYDY8zFyS5515beN5LHufNdhTlHiO7nK4fG9z5Ssw==</ds:SignatureValue>
+		<ds:KeyInfo Id="Certificate-019ffa77-c5c7-72af-b549-db41f0c8100c">
+			<ds:X509Data>
+				<ds:X509Certificate>MIIHhjCCBm6gAwIBAgIQSOSlyjvRFUlfo/hUFNAvqDANBgkqhkiG9w0BAQsFADBLMQswCQYDVQQGEwJFUzERMA8GA1UECgwIRk5NVC1SQ00xDjAMBgNVBAsMBUNlcmVzMRkwFwYDVQQDDBBBQyBGTk1UIFVzdWFyaW9zMB4XDTIwMTEwNTEzMDQyMFoXDTI0MTEwNTEzMDQyMFowgYUxCzAJBgNVBAYTAkVTMRgwFgYDVQQFEw9JRENFUy05OTk5OTk5OVIxEDAOBgNVBCoMB1BSVUVCQVMxGjAYBgNVBAQMEUVJREFTIENFUlRJRklDQURPMS4wLAYDVQQDDCVFSURBUyBDRVJUSUZJQ0FETyBQUlVFQkFTIC0gOTk5OTk5OTlSMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQIDAQABo4IEKTCCBCUwgZIGA1UdEQSBijCBh4Edc29wb3J0ZV90ZWNuaWNvX2NlcmVzQGZubXQuZXOkZjBkMRgwFgYJKwYBBAGsZgEEDAk5OTk5OTk5OVIxGjAYBgkrBgEEAaxmAQMMC0NFUlRJRklDQURPMRQwEgYJKwYBBAGsZgECDAVFSURBUzEWMBQGCSsGAQQBrGYBAQwHUFJVRUJBUzAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIF4DAdBgNVHSUEFjAUBggrBgEFBQcDBAYIKwYBBQUHAwIwHQYDVR0OBBYEFE5aHiQQRwVYJzmmkfG/i5MxmMNdMB8GA1UdIwQYMBaAFLHUT8QjefpEBQnG6znP6DWwuCBkMIGCBggrBgEFBQcBAQR2MHQwPQYIKwYBBQUHMAGGMWh0dHA6Ly9vY3NwdXN1LmNlcnQuZm5tdC5lcy9vY3NwdXN1L09jc3BSZXNwb25kZXIwMwYIKwYBBQUHMAKGJ2h0dHA6Ly93d3cuY2VydC5mbm10LmVzL2NlcnRzL0FDVVNVLmNydDCCARUGA1UdIASCAQwwggEIMIH6BgorBgEEAaxmAwoBMIHrMCkGCCsGAQUFBwIBFh1odHRwOi8vd3d3LmNlcnQuZm5tdC5lcy9kcGNzLzCBvQYIKwYBBQUHAgIwgbAMga1DZXJ0aWZpY2FkbyBjdWFsaWZpY2FkbyBkZSBmaXJtYSBlbGVjdHLDs25pY2EuIFN1amV0byBhIGxhcyBjb25kaWNpb25lcyBkZSB1c28gZXhwdWVzdGFzIGVuIGxhIERQQyBkZSBsYSBGTk1ULVJDTSBjb24gTklGOiBRMjgyNjAwNC1KIChDL0pvcmdlIEp1YW4gMTA2LTI4MDA5LU1hZHJpZC1Fc3Bhw7FhKTAJBgcEAIvsQAEAMIG6BggrBgEFBQcBAwSBrTCBqjAIBgYEAI5GAQEwCwYGBACORgEDAgEPMBMGBgQAjkYBBjAJBgcEAI5GAQYBMHwGBgQAjkYBBTByMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lcy5wZGYTAmVzMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lbi5wZGYTAmVuMIG1BgNVHR8Ega0wgaowgaeggaSggaGGgZ5sZGFwOi8vbGRhcHVzdS5jZXJ0LmZubXQuZXMvY249Q1JMMzc0OCxjbj1BQyUyMEZOTVQlMjBVc3VhcmlvcyxvdT1DRVJFUyxvPUZOTVQtUkNNLGM9RVM/Y2VydGlmaWNhdGVSZXZvY2F0aW9uTGlzdDtiaW5hcnk/YmFzZT9vYmplY3RjbGFzcz1jUkxEaXN0cmlidXRpb25Qb2ludDANBgkqhkiG9w0BAQsFAAOCAQEAH4t5/v/SLsm/dXRDw4QblCmTX+5pgXJ+4G1Lb3KTSPtDJ0UbQiAMUx+iqDDOoMHU5H7po/HZLJXgNwvKLoiLbl5/q6Mqasif87fa6awNkuz/Y6dvXw0UOJh+Ud/Wrk0EyaP9ZtrLVsraUOobNyS6g+lOrCxRrNxGRK2yAeotO6LEo1y3b7CB+Amd2jDq8lY3AtCYlrhuCaTf0AD9IBYYmigHzFD/VH5a8uG95l6J85FQG7tMsG6UQHFM2EmNhpbrYH+ihetz3UhzcC5Fd/P1X7pGBymQgbCyBjCRf/HEVzyoHL72uMp2I4JXX4v8HABZT8xtlDY4LE0am9keJhaNcg==</ds:X509Certificate>
+			</ds:X509Data>
+			<ds:KeyValue>
+				<ds:RSAKeyValue>
+					<ds:Modulus>ujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQ==</ds:Modulus>
+					<ds:Exponent>AQAB</ds:Exponent>
+				</ds:RSAKeyValue>
+			</ds:KeyValue>
+		</ds:KeyInfo>
+		<ds:Object>
+			<xades:QualifyingProperties xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" Id="Signature-019ffa77-c5c7-72af-b549-db41f0c8100c-QualifyingProperties" Target="#Signature-019ffa77-c5c7-72af-b549-db41f0c8100c-Signature">
+				<xades:SignedProperties Id="Signature-019ffa77-c5c7-72af-b549-db41f0c8100c-SignedProperties">
+					<xades:SignedSignatureProperties>
+						<xades:SigningTime>2022-02-01T04:00:00+00:00</xades:SigningTime>
+						<xades:SigningCertificate>
+							<xades:Cert>
+								<xades:CertDigest>
+									<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+									<ds:DigestValue>VmNYwDiCBBXJX/IL1AUYj7uHouM2Jcp3ZkeqmB+FKGTTwXIIZnCWmZVhCSB7uNoV6Xee7nZVkMqeCMQk3tGR0g==</ds:DigestValue>
+								</xades:CertDigest>
+								<xades:IssuerSerial>
+									<ds:X509IssuerName>CN=AC FNMT Usuarios,OU=Ceres,O=FNMT-RCM,C=ES</ds:X509IssuerName>
+									<ds:X509SerialNumber>96891622000445695554354105786026700712</ds:X509SerialNumber>
+								</xades:IssuerSerial>
+							</xades:Cert>
+						</xades:SigningCertificate>
+					</xades:SignedSignatureProperties>
+					<xades:SignedDataObjectProperties>
+						<xades:DataObjectFormat ObjectReference="#Reference-019ffa77-c5c7-72af-b549-db41f0c8100c">
+							<xades:Description>Fattura PA</xades:Description>
+							<xades:ObjectIdentifier>
+								<xades:Identifier Qualifier="OIDAsURN">urn:oid:1.2.840.10003.5.109.10</xades:Identifier>
+								<xades:Description></xades:Description>
+							</xades:ObjectIdentifier>
+							<xades:MimeType>text/xml</xades:MimeType>
+							<xades:Encoding></xades:Encoding>
+						</xades:DataObjectFormat>
+					</xades:SignedDataObjectProperties>
+				</xades:SignedProperties>
+			</xades:QualifyingProperties>
+		</ds:Object>
+	</ds:Signature>
+</p:FatturaElettronica>

--- a/test/data/fatturapa.gobl/out/invoice-retained-cp.json
+++ b/test/data/fatturapa.gobl/out/invoice-retained-cp.json
@@ -1,0 +1,168 @@
+{
+	"$regime": "IT",
+	"$addons": [
+		"it-sdi-v1"
+	],
+	"$tags": [
+		"freelance"
+	],
+	"uuid": "00000000-0000-0000-0000-000000000000",
+	"type": "standard",
+	"code": "SAMPLE-004",
+	"issue_date": "2023-03-02",
+	"currency": "EUR",
+	"tax": {
+		"ext": {
+			"it-sdi-document-type": "TD06",
+			"it-sdi-format": "FPR12"
+		}
+	},
+	"supplier": {
+		"name": "Studio Bianchi",
+		"tax_id": {
+			"country": "IT",
+			"code": "12345678903"
+		},
+		"addresses": [
+			{
+				"num": "1",
+				"street": "VIALE DELLA LIBERTÀ",
+				"locality": "ROMA",
+				"region": "RM",
+				"code": "00100",
+				"country": "IT"
+			}
+		],
+		"ext": {
+			"it-sdi-fiscal-regime": "RF01"
+		}
+	},
+	"customer": {
+		"name": "Impresa Verdi SRL",
+		"tax_id": {
+			"country": "IT",
+			"code": "13029381004"
+		},
+		"inboxes": [
+			{
+				"key": "it-sdi-code",
+				"code": "ABCDEF1"
+			}
+		],
+		"addresses": [
+			{
+				"num": "32",
+				"street": "VIALE DELI LAVORATORI",
+				"locality": "FIRENZE",
+				"region": "FI",
+				"code": "50100",
+				"country": "IT"
+			}
+		]
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "1.00",
+			"item": {
+				"name": "Consulenza tecnica",
+				"price": "1000.00"
+			},
+			"sum": "1000.00",
+			"taxes": [
+				{
+					"cat": "VAT",
+					"key": "standard",
+					"percent": "22.00%"
+				},
+				{
+					"cat": "IRPEF",
+					"percent": "20.00%",
+					"ext": {
+						"it-sdi-retained": "A"
+					}
+				},
+				{
+					"cat": "CP",
+					"percent": "4.00%",
+					"ext": {
+						"it-sdi-retained": "A"
+					}
+				}
+			],
+			"total": "1000.00"
+		}
+	],
+	"payment": {
+		"terms": {
+			"key": "pending"
+		},
+		"instructions": {
+			"key": "credit-transfer",
+			"credit_transfer": [
+				{
+					"iban": "IT60X0542811101000000123456"
+				}
+			],
+			"ext": {
+				"it-sdi-payment-means": "MP05"
+			}
+		}
+	},
+	"totals": {
+		"sum": "1000.00",
+		"total": "1000.00",
+		"taxes": {
+			"categories": [
+				{
+					"code": "VAT",
+					"rates": [
+						{
+							"key": "standard",
+							"base": "1000.00",
+							"percent": "22.00%",
+							"amount": "220.00"
+						}
+					],
+					"amount": "220.00"
+				},
+				{
+					"code": "IRPEF",
+					"retained": true,
+					"rates": [
+						{
+							"ext": {
+								"it-sdi-retained": "A"
+							},
+							"base": "1000.00",
+							"percent": "20.00%",
+							"amount": "200.00"
+						}
+					],
+					"amount": "200.00"
+				},
+				{
+					"code": "CP",
+					"retained": true,
+					"rates": [
+						{
+							"ext": {
+								"it-sdi-retained": "A"
+							},
+							"base": "1000.00",
+							"percent": "4.00%",
+							"amount": "40.00"
+						}
+					],
+					"amount": "40.00"
+				}
+			],
+			"sum": "220.00",
+			"retained": "240.00"
+		},
+		"tax": "220.00",
+		"total_with_tax": "1220.00",
+		"retained_tax": "240.00",
+		"payable": "980.00"
+	}
+}

--- a/test/data/gobl.fatturapa/invoice-retained-cp.json
+++ b/test/data/gobl.fatturapa/invoice-retained-cp.json
@@ -1,0 +1,186 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "019ffa77-c5c7-72af-b549-db41f0c8100c",
+		"dig": {
+			"alg": "sha256",
+			"val": "e1edf606a17ffdba876c65cfbac5a3dc2b18adcb9a06ba4c4fad3b0328af5709"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "IT",
+		"$addons": [
+			"it-sdi-v1"
+		],
+		"$tags": [
+			"freelance"
+		],
+		"uuid": "019891f4-3d2c-73a1-b8fe-4f5c1a8e2b70",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "004",
+		"issue_date": "2023-03-02",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"it-sdi-document-type": "TD06",
+				"it-sdi-format": "FPR12"
+			}
+		},
+		"supplier": {
+			"name": "Studio Bianchi",
+			"tax_id": {
+				"country": "IT",
+				"code": "12345678903"
+			},
+			"people": [
+				{
+					"name": {
+						"given": "LUCIA",
+						"surname": "BIANCHI"
+					}
+				}
+			],
+			"addresses": [
+				{
+					"num": "1",
+					"street": "VIALE DELLA LIBERTÀ",
+					"locality": "ROMA",
+					"region": "RM",
+					"code": "00100",
+					"country": "IT"
+				}
+			],
+			"ext": {
+				"it-sdi-fiscal-regime": "RF01"
+			}
+		},
+		"customer": {
+			"name": "Impresa Verdi SRL",
+			"tax_id": {
+				"country": "IT",
+				"code": "13029381004"
+			},
+			"inboxes": [
+				{
+					"key": "it-sdi-code",
+					"code": "ABCDEF1"
+				}
+			],
+			"addresses": [
+				{
+					"num": "32",
+					"street": "VIALE DELI LAVORATORI",
+					"locality": "FIRENZE",
+					"region": "FI",
+					"code": "50100",
+					"country": "IT"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Consulenza tecnica",
+					"price": "1000.00"
+				},
+				"sum": "1000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "22.0%"
+					},
+					{
+						"cat": "IRPEF",
+						"percent": "20.0%",
+						"ext": {
+							"it-sdi-retained": "A"
+						}
+					},
+					{
+						"cat": "CP",
+						"percent": "4.0%",
+						"ext": {
+							"it-sdi-retained": "A"
+						}
+					}
+				],
+				"total": "1000.00"
+			}
+		],
+		"payment": {
+			"instructions": {
+				"key": "credit-transfer",
+				"credit_transfer": [
+					{
+						"iban": "IT60X0542811101000000123456"
+					}
+				],
+				"ext": {
+					"it-sdi-payment-means": "MP05"
+				}
+			}
+		},
+		"totals": {
+			"sum": "1000.00",
+			"total": "1000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1000.00",
+								"percent": "22.0%",
+								"amount": "220.00"
+							}
+						],
+						"amount": "220.00"
+					},
+					{
+						"code": "IRPEF",
+						"retained": true,
+						"rates": [
+							{
+								"ext": {
+									"it-sdi-retained": "A"
+								},
+								"base": "1000.00",
+								"percent": "20.0%",
+								"amount": "200.00"
+							}
+						],
+						"amount": "200.00"
+					},
+					{
+						"code": "CP",
+						"retained": true,
+						"rates": [
+							{
+								"ext": {
+									"it-sdi-retained": "A"
+								},
+								"base": "1000.00",
+								"percent": "4.0%",
+								"amount": "40.00"
+							}
+						],
+						"amount": "40.00"
+					}
+				],
+				"sum": "220.00",
+				"retained": "240.00"
+			},
+			"tax": "220.00",
+			"total_with_tax": "1220.00",
+			"retained_tax": "240.00",
+			"payable": "980.00"
+		}
+	}
+}

--- a/test/data/gobl.fatturapa/out/invoice-retained-cp.xml
+++ b/test/data/gobl.fatturapa/out/invoice-retained-cp.xml
@@ -1,0 +1,165 @@
+<p:FatturaElettronica xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" versione="FPR12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 https://www.fatturapa.gov.it/export/documenti/fatturapa/v1.2.2/Schema_del_file_xml_FatturaPA_v1.2.2.xsd">
+	<FatturaElettronicaHeader>
+		<DatiTrasmissione>
+			<IdTrasmittente>
+				<IdPaese>IT</IdPaese>
+				<IdCodice>01234567890</IdCodice>
+			</IdTrasmittente>
+			<ProgressivoInvio>019ffa77</ProgressivoInvio>
+			<FormatoTrasmissione>FPR12</FormatoTrasmissione>
+			<CodiceDestinatario>ABCDEF1</CodiceDestinatario>
+		</DatiTrasmissione>
+		<CedentePrestatore>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>12345678903</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>Studio Bianchi</Denominazione>
+				</Anagrafica>
+				<RegimeFiscale>RF01</RegimeFiscale>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>VIALE DELLA LIBERTÀ</Indirizzo>
+				<NumeroCivico>1</NumeroCivico>
+				<CAP>00100</CAP>
+				<Comune>ROMA</Comune>
+				<Provincia>RM</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+			<Contatti></Contatti>
+		</CedentePrestatore>
+		<CessionarioCommittente>
+			<DatiAnagrafici>
+				<IdFiscaleIVA>
+					<IdPaese>IT</IdPaese>
+					<IdCodice>13029381004</IdCodice>
+				</IdFiscaleIVA>
+				<Anagrafica>
+					<Denominazione>Impresa Verdi SRL</Denominazione>
+				</Anagrafica>
+			</DatiAnagrafici>
+			<Sede>
+				<Indirizzo>VIALE DELI LAVORATORI</Indirizzo>
+				<NumeroCivico>32</NumeroCivico>
+				<CAP>50100</CAP>
+				<Comune>FIRENZE</Comune>
+				<Provincia>FI</Provincia>
+				<Nazione>IT</Nazione>
+			</Sede>
+		</CessionarioCommittente>
+	</FatturaElettronicaHeader>
+	<FatturaElettronicaBody>
+		<DatiGenerali>
+			<DatiGeneraliDocumento>
+				<TipoDocumento>TD06</TipoDocumento>
+				<Divisa>EUR</Divisa>
+				<Data>2023-03-02</Data>
+				<Numero>SAMPLE-004</Numero>
+				<DatiRitenuta>
+					<TipoRitenuta>RT01</TipoRitenuta>
+					<ImportoRitenuta>200.00</ImportoRitenuta>
+					<AliquotaRitenuta>20.00</AliquotaRitenuta>
+					<CausalePagamento>A</CausalePagamento>
+				</DatiRitenuta>
+				<DatiRitenuta>
+					<TipoRitenuta>RT06</TipoRitenuta>
+					<ImportoRitenuta>40.00</ImportoRitenuta>
+					<AliquotaRitenuta>4.00</AliquotaRitenuta>
+					<CausalePagamento>A</CausalePagamento>
+				</DatiRitenuta>
+				<ImportoTotaleDocumento>980.00</ImportoTotaleDocumento>
+			</DatiGeneraliDocumento>
+		</DatiGenerali>
+		<DatiBeniServizi>
+			<DettaglioLinee>
+				<NumeroLinea>1</NumeroLinea>
+				<Descrizione>Consulenza tecnica</Descrizione>
+				<Quantita>1.00</Quantita>
+				<PrezzoUnitario>1000.00</PrezzoUnitario>
+				<PrezzoTotale>1000.00</PrezzoTotale>
+				<AliquotaIVA>22.00</AliquotaIVA>
+				<Ritenuta>SI</Ritenuta>
+			</DettaglioLinee>
+			<DatiRiepilogo>
+				<AliquotaIVA>22.00</AliquotaIVA>
+				<ImponibileImporto>1000.00</ImponibileImporto>
+				<Imposta>220.00</Imposta>
+			</DatiRiepilogo>
+		</DatiBeniServizi>
+		<DatiPagamento>
+			<CondizioniPagamento>TP02</CondizioniPagamento>
+			<DettaglioPagamento>
+				<ModalitaPagamento>MP05</ModalitaPagamento>
+				<ImportoPagamento>980.00</ImportoPagamento>
+				<IBAN>IT60X0542811101000000123456</IBAN>
+			</DettaglioPagamento>
+		</DatiPagamento>
+	</FatturaElettronicaBody>
+	<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="Signature-019ffa77-c5c7-72af-b549-db41f0c8100c-Signature">
+		<ds:SignedInfo>
+			<ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"></ds:CanonicalizationMethod>
+			<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"></ds:SignatureMethod>
+			<ds:Reference Id="Reference-019ffa77-c5c7-72af-b549-db41f0c8100c" Type="http://www.w3.org/2000/09/xmldsig#Object" URI="">
+				<ds:Transforms>
+					<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>
+				</ds:Transforms>
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>KaEuaRu6EYhT72f2u0Bty/dqctCB5xDndgqM8QB4dfIJ0qmEPF5vCsai4Lh8eCUa64WbYdYkKc7ktlb3w5OPvw==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference URI="#Certificate-019ffa77-c5c7-72af-b549-db41f0c8100c">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>cmJnBKVOkY8yXTRrlo6srtKjAsr7v+1iZYCDiTvokgG1fXbyeE2YHAkXlbLwh66TeI38Sn17hkQh0oZnlr+1wA==</ds:DigestValue>
+			</ds:Reference>
+			<ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#Signature-019ffa77-c5c7-72af-b549-db41f0c8100c-SignedProperties">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+				<ds:DigestValue>977fydVn77nr8hWQXRr+UAd3dju6WL3mm2kU44m4VRi8nQAypBCkQn7PxiZZH1wGkEGo0qrDPsxOP4P2AXv1EQ==</ds:DigestValue>
+			</ds:Reference>
+		</ds:SignedInfo>
+		<ds:SignatureValue Id="Signature-019ffa77-c5c7-72af-b549-db41f0c8100c-SignatureValue">b0IDwyAFGvpMB2+5+rPTvR4NoBryesQlXakQuaOxcwpa4YX8uwGPXAeigu7w2q9FslRa4RIoXESc90oxPR8T7Je2cNxKq7QeKdXXEu+tvFWD1kdRvEFiG+HsD43ivPvvalFykMJU8VzrPPTZxOUpQKif460I6tAMvFdcIHkGAOa5RkWG9y6pAaEdu+loJQ2FX0CDLl1wokhdUMuGXDA/z+SyuUrNa1zNhEqLEYRGYYrAboUYrtSjbcAMtrQX+eqIDk6yrcMVX+wuia327q+PMpE0KrXDqp3G0mY6fp6bf8UgraYDY8zFyS5515beN5LHufNdhTlHiO7nK4fG9z5Ssw==</ds:SignatureValue>
+		<ds:KeyInfo Id="Certificate-019ffa77-c5c7-72af-b549-db41f0c8100c">
+			<ds:X509Data>
+				<ds:X509Certificate>MIIHhjCCBm6gAwIBAgIQSOSlyjvRFUlfo/hUFNAvqDANBgkqhkiG9w0BAQsFADBLMQswCQYDVQQGEwJFUzERMA8GA1UECgwIRk5NVC1SQ00xDjAMBgNVBAsMBUNlcmVzMRkwFwYDVQQDDBBBQyBGTk1UIFVzdWFyaW9zMB4XDTIwMTEwNTEzMDQyMFoXDTI0MTEwNTEzMDQyMFowgYUxCzAJBgNVBAYTAkVTMRgwFgYDVQQFEw9JRENFUy05OTk5OTk5OVIxEDAOBgNVBCoMB1BSVUVCQVMxGjAYBgNVBAQMEUVJREFTIENFUlRJRklDQURPMS4wLAYDVQQDDCVFSURBUyBDRVJUSUZJQ0FETyBQUlVFQkFTIC0gOTk5OTk5OTlSMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQIDAQABo4IEKTCCBCUwgZIGA1UdEQSBijCBh4Edc29wb3J0ZV90ZWNuaWNvX2NlcmVzQGZubXQuZXOkZjBkMRgwFgYJKwYBBAGsZgEEDAk5OTk5OTk5OVIxGjAYBgkrBgEEAaxmAQMMC0NFUlRJRklDQURPMRQwEgYJKwYBBAGsZgECDAVFSURBUzEWMBQGCSsGAQQBrGYBAQwHUFJVRUJBUzAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIF4DAdBgNVHSUEFjAUBggrBgEFBQcDBAYIKwYBBQUHAwIwHQYDVR0OBBYEFE5aHiQQRwVYJzmmkfG/i5MxmMNdMB8GA1UdIwQYMBaAFLHUT8QjefpEBQnG6znP6DWwuCBkMIGCBggrBgEFBQcBAQR2MHQwPQYIKwYBBQUHMAGGMWh0dHA6Ly9vY3NwdXN1LmNlcnQuZm5tdC5lcy9vY3NwdXN1L09jc3BSZXNwb25kZXIwMwYIKwYBBQUHMAKGJ2h0dHA6Ly93d3cuY2VydC5mbm10LmVzL2NlcnRzL0FDVVNVLmNydDCCARUGA1UdIASCAQwwggEIMIH6BgorBgEEAaxmAwoBMIHrMCkGCCsGAQUFBwIBFh1odHRwOi8vd3d3LmNlcnQuZm5tdC5lcy9kcGNzLzCBvQYIKwYBBQUHAgIwgbAMga1DZXJ0aWZpY2FkbyBjdWFsaWZpY2FkbyBkZSBmaXJtYSBlbGVjdHLDs25pY2EuIFN1amV0byBhIGxhcyBjb25kaWNpb25lcyBkZSB1c28gZXhwdWVzdGFzIGVuIGxhIERQQyBkZSBsYSBGTk1ULVJDTSBjb24gTklGOiBRMjgyNjAwNC1KIChDL0pvcmdlIEp1YW4gMTA2LTI4MDA5LU1hZHJpZC1Fc3Bhw7FhKTAJBgcEAIvsQAEAMIG6BggrBgEFBQcBAwSBrTCBqjAIBgYEAI5GAQEwCwYGBACORgEDAgEPMBMGBgQAjkYBBjAJBgcEAI5GAQYBMHwGBgQAjkYBBTByMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lcy5wZGYTAmVzMDcWMWh0dHBzOi8vd3d3LmNlcnQuZm5tdC5lcy9wZHMvUERTQUNVc3Vhcmlvc19lbi5wZGYTAmVuMIG1BgNVHR8Ega0wgaowgaeggaSggaGGgZ5sZGFwOi8vbGRhcHVzdS5jZXJ0LmZubXQuZXMvY249Q1JMMzc0OCxjbj1BQyUyMEZOTVQlMjBVc3VhcmlvcyxvdT1DRVJFUyxvPUZOTVQtUkNNLGM9RVM/Y2VydGlmaWNhdGVSZXZvY2F0aW9uTGlzdDtiaW5hcnk/YmFzZT9vYmplY3RjbGFzcz1jUkxEaXN0cmlidXRpb25Qb2ludDANBgkqhkiG9w0BAQsFAAOCAQEAH4t5/v/SLsm/dXRDw4QblCmTX+5pgXJ+4G1Lb3KTSPtDJ0UbQiAMUx+iqDDOoMHU5H7po/HZLJXgNwvKLoiLbl5/q6Mqasif87fa6awNkuz/Y6dvXw0UOJh+Ud/Wrk0EyaP9ZtrLVsraUOobNyS6g+lOrCxRrNxGRK2yAeotO6LEo1y3b7CB+Amd2jDq8lY3AtCYlrhuCaTf0AD9IBYYmigHzFD/VH5a8uG95l6J85FQG7tMsG6UQHFM2EmNhpbrYH+ihetz3UhzcC5Fd/P1X7pGBymQgbCyBjCRf/HEVzyoHL72uMp2I4JXX4v8HABZT8xtlDY4LE0am9keJhaNcg==</ds:X509Certificate>
+			</ds:X509Data>
+			<ds:KeyValue>
+				<ds:RSAKeyValue>
+					<ds:Modulus>ujAnB2L5X2Bm42S5f/axKFu1QsAcZGJAeYELZZJ04jriBu3E8V3Rus3tUxfQ+ylqBm0bNWgHfP+gekosHaYoJNQmAVBuwpd183uHksTRUtbeOAFS2xd7v29stM7ARkec+WVV+SK8G6HECIB0VIAMoB2tVs0y6XRVRcjE4I7kH1h3ZbMIzvW43B4hxruYtXcvozGwvZpxQKVrjEY8IXH5+aXHM8WLCba4I06FyhvI+2/9WUPN2YvDoml7lQM4edgepTEZifq2ZPHGpCC5NhSXj2ab5FtnGTMgUaWH6tCljT0kOdfJBOHnIWOw4dBdgkik2CuxwGyMrq/P5VqQIC2hXQ==</ds:Modulus>
+					<ds:Exponent>AQAB</ds:Exponent>
+				</ds:RSAKeyValue>
+			</ds:KeyValue>
+		</ds:KeyInfo>
+		<ds:Object>
+			<xades:QualifyingProperties xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" Id="Signature-019ffa77-c5c7-72af-b549-db41f0c8100c-QualifyingProperties" Target="#Signature-019ffa77-c5c7-72af-b549-db41f0c8100c-Signature">
+				<xades:SignedProperties Id="Signature-019ffa77-c5c7-72af-b549-db41f0c8100c-SignedProperties">
+					<xades:SignedSignatureProperties>
+						<xades:SigningTime>2022-02-01T04:00:00+00:00</xades:SigningTime>
+						<xades:SigningCertificate>
+							<xades:Cert>
+								<xades:CertDigest>
+									<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"></ds:DigestMethod>
+									<ds:DigestValue>VmNYwDiCBBXJX/IL1AUYj7uHouM2Jcp3ZkeqmB+FKGTTwXIIZnCWmZVhCSB7uNoV6Xee7nZVkMqeCMQk3tGR0g==</ds:DigestValue>
+								</xades:CertDigest>
+								<xades:IssuerSerial>
+									<ds:X509IssuerName>CN=AC FNMT Usuarios,OU=Ceres,O=FNMT-RCM,C=ES</ds:X509IssuerName>
+									<ds:X509SerialNumber>96891622000445695554354105786026700712</ds:X509SerialNumber>
+								</xades:IssuerSerial>
+							</xades:Cert>
+						</xades:SigningCertificate>
+					</xades:SignedSignatureProperties>
+					<xades:SignedDataObjectProperties>
+						<xades:DataObjectFormat ObjectReference="#Reference-019ffa77-c5c7-72af-b549-db41f0c8100c">
+							<xades:Description>Fattura PA</xades:Description>
+							<xades:ObjectIdentifier>
+								<xades:Identifier Qualifier="OIDAsURN">urn:oid:1.2.840.10003.5.109.10</xades:Identifier>
+								<xades:Description></xades:Description>
+							</xades:ObjectIdentifier>
+							<xades:MimeType>text/xml</xades:MimeType>
+							<xades:Encoding></xades:Encoding>
+						</xades:DataObjectFormat>
+					</xades:SignedDataObjectProperties>
+				</xades:SignedProperties>
+			</xades:QualifyingProperties>
+		</ds:Object>
+	</ds:Signature>
+</p:FatturaElettronica>


### PR DESCRIPTION
## Context

`TipoRitenuta` codes were listed by hand in two switch statements, one per conversion direction, and both stopped at RT05. The Italian regime already publishes the mapping — every retained tax category carries its code in `Map["fatturapa-tipo-ritenuta"]` — so the switches were a second copy of that list, missing its sixth entry.

The practical effect: `CP` (*altro contributo previdenziale*) could not be emitted as RT06, and an incoming invoice carrying RT06 failed to parse. Neither direction needed a GOBL upgrade — the map has covered all six codes for a long time.

## Changes

- `findCodeTaxType` reads the code from the tax category definition instead of a switch, so RT06 now emits.
- `convertRetainedTaxType` looks the code up across the regime's categories, so RT06 now parses.
- Added `invoice-retained-cp` fixtures in both directions: an invoice withholding IRPEF (RT01) and CP (RT06) together, emitting two `DatiRitenuta` blocks.
- Added tests pinning all six codes both ways, plus a round trip over every retained category the regime defines — a new category is now covered without touching this package, and two categories claiming one code would fail the round trip.

## Next

Nothing else in this change. Withholdings that apply to a fraction of the taxable base still need the base expressed as its own line, since a tax combo has no base of its own.